### PR TITLE
Define how providers are registered

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
@@ -17,13 +17,29 @@
 package org.eclipse.microprofile.rest.client;
 
 import javax.annotation.Priority;
+import javax.ws.rs.core.Configurable;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.ServiceLoader;
+import java.util.function.ToIntFunction;
 
-public abstract class RestClientBuilder {
+/**
+ * <p>
+ * This is the main entry point for creating a Type Safe Rest Client.  Implementations are expected
+ * to implement this class and register a service provider via {@link ServiceLoader} that works within their implementation.
+ * <p>
+ * Invoking <pre>RestClientBuilder.newBuilder()</pre> is intended to always create a new instance, not use a cached version.
+ * <p>
+ * If multiple implementations of RestClientBuilder are discovered, the one with the highest value of the {@link Priority} annotation is used
+ * <p>
+ * The {@link ServiceLoader} will first search via the current Thread's Context ClassLoader, then {@link RestClientBuilder}'s {@link ClassLoader}
+ * <p>
+ * The <pre>RestClientBuilder</pre> is a {@link Configurable} class as defined by JAX-RS.  This allows a user to register providers,
+ * implementation specific configuration.
+ */
+public abstract class RestClientBuilder implements Configurable<RestClientBuilder>{
     public static RestClientBuilder newBuilder() {
         ServiceLoader<RestClientBuilder> loader = ServiceLoader.load(RestClientBuilder.class);
         List<RestClientBuilder> clientBuilders = new ArrayList<>();
@@ -34,7 +50,31 @@ public abstract class RestClientBuilder {
         if(clientBuilders.size() == 0) {
             throw new RuntimeException("No implementation of '"+RestClientBuilder.class.getSimpleName()+"' found");
         }
-        clientBuilders.sort(Comparator.comparingInt(value -> {
+        clientBuilders.sort(Comparator.comparingInt(priorityComparator()).reversed());
+        return clientBuilders.get(0);
+    }
+
+    /**
+     * Specifies the base URL to be used when making requests.  Assuming that the interface has a <pre>@Path("/api")</pre> at the interface level
+     * and a <pre>url</pre> is given with <pre>http://my-service:8080/service</pre> then all REST calls will be invoked with a <pre>url</pre> of
+     * <pre>http://my-service:8080/service/api</pre> in addition to any <pre>@Path</pre> annotations included on the method.
+     * @param url the base Url for the service.
+     * @return the current builder with the baseUrl set
+     */
+    public abstract RestClientBuilder baseUrl(URL url);
+
+    /**
+     * Based on the configured RestClientBuilder, creates a new instance of the given REST interface to invoke API calls against.
+     * @param clazz the interface that defines REST API methods for use
+     * @param <T> the type of the interface
+     * @return a new instance of an implementation of this REST interface that
+     * @throws IllegalStateException if not all pre-requisites are satisfied for the builder, this exception may get thrown.  For instance, if a URL
+     *  has not been set.
+     */
+    public abstract <T> T build(Class<T> clazz) throws IllegalStateException;
+
+    private static ToIntFunction<Object> priorityComparator() {
+        return value -> {
             Priority priority = value.getClass().getAnnotation(Priority.class);
             if (priority == null) {
                 return 1;
@@ -42,11 +82,6 @@ public abstract class RestClientBuilder {
             else {
                 return priority.value();
             }
-        }).reversed());
-        return clientBuilders.get(0);
+        };
     }
-
-    public abstract RestClientBuilder baseUrl(URL url);
-
-    public abstract <T> T build(Class<T> clazz);
 }

--- a/api/src/main/java/org/eclipse/microprofile/rest/client/annotation/RegisterProviders.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/annotation/RegisterProviders.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * When annotation is placed at the interface level of a REST API definition, the providers listed will be registered upon proxying.
+ * <p>
+ * If a provider listed is not found on the classpath, it is ignored.  If a provider is listed, but is not a valid provider, then an
+ * {@link IllegalArgumentException} is thrown indicating that the provider is invalid.
+ */
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface RegisterProviders {
+    /**
+     * @return the list of valid provider classes to register on this client interface
+     */
+    Class<?>[] value();
+}

--- a/api/src/test/java/org/eclipse/microprofile/rest/client/AbstractBuilder.java
+++ b/api/src/test/java/org/eclipse/microprofile/rest/client/AbstractBuilder.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client;
+
+import javax.ws.rs.core.Configurable;
+import javax.ws.rs.core.Configuration;
+import java.util.Map;
+
+public abstract class AbstractBuilder extends RestClientBuilder implements Configurable<RestClientBuilder> {
+    @Override
+    public Configuration getConfiguration() {
+        return null;
+    }
+
+    @Override
+    public AbstractBuilder property(String s, Object o) {
+        return this;
+    }
+
+    @Override
+    public AbstractBuilder register(Class<?> aClass) {
+        return this;
+    }
+
+    @Override
+    public AbstractBuilder register(Class<?> aClass, int i) {
+        return this;
+    }
+
+    @Override
+    public AbstractBuilder register(Class<?> aClass, Class<?>... classes) {
+        return this;
+    }
+
+    @Override
+    public AbstractBuilder register(Class<?> aClass, Map<Class<?>, Integer> map) {
+        return this;
+    }
+
+    @Override
+    public AbstractBuilder register(Object o) {
+        return this;
+    }
+
+    @Override
+    public AbstractBuilder register(Object o, int i) {
+        return this;
+    }
+
+    @Override
+    public AbstractBuilder register(Object o, Class<?>... classes) {
+        return this;
+    }
+
+    @Override
+    public AbstractBuilder register(Object o, Map<Class<?>, Integer> map) {
+        return this;
+    }
+}

--- a/api/src/test/java/org/eclipse/microprofile/rest/client/BuilderImpl1.java
+++ b/api/src/test/java/org/eclipse/microprofile/rest/client/BuilderImpl1.java
@@ -20,7 +20,7 @@ import javax.annotation.Priority;
 import java.net.URL;
 
 @Priority(1)
-public class BuilderImpl1 extends RestClientBuilder {
+public class BuilderImpl1 extends AbstractBuilder {
     @Override
     public RestClientBuilder baseUrl(URL url) {
         throw new IllegalStateException("not implemented");

--- a/api/src/test/java/org/eclipse/microprofile/rest/client/BuilderImpl2.java
+++ b/api/src/test/java/org/eclipse/microprofile/rest/client/BuilderImpl2.java
@@ -20,7 +20,7 @@ import javax.annotation.Priority;
 import java.net.URL;
 
 @Priority(2)
-public class BuilderImpl2 extends RestClientBuilder {
+public class BuilderImpl2 extends AbstractBuilder {
     @Override
     public RestClientBuilder baseUrl(URL url) {
         throw new IllegalStateException("not implemented");

--- a/spec/src/main/asciidoc/microprofile-rest-client.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-rest-client.asciidoc
@@ -45,4 +45,6 @@ include::clientexamples.asciidoc[]
 
 include::programmatic_lookup.asciidoc[]
 
+include::providers.asciidoc[]
+
 include::release_notes.asciidoc[]

--- a/spec/src/main/asciidoc/programmatic_lookup.asciidoc
+++ b/spec/src/main/asciidoc/programmatic_lookup.asciidoc
@@ -25,9 +25,9 @@ Type Safe Rest Clients support both programmatic look up and CDI injection appro
 ----
 public class SomeService {
    public Response doWorkAgainstApi(URL apiUrl, ApiModel apiModel) {
-       RemoteApi remoteApi = TypeSafeClientBuilder.newBuilder()
+       RemoteApi remoteApi = RestClientBuilder.newBuilder()
             .baseUrl(apiUrl)
-            .proxy(RemoteApi.class);
+            .build(RemoteApi.class);
        return remoteApi.execute(apiModel);
    }
 }

--- a/spec/src/main/asciidoc/providers.asciidoc
+++ b/spec/src/main/asciidoc/providers.asciidoc
@@ -1,0 +1,52 @@
+//
+// Copyright (c) 2017 Contributors to the Eclipse Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+[[programmatic_lookup]]
+== MicroProfile Rest Client Provider Registration
+
+The RestClientBuilder interface extends the `Configurable` interface from JAX-RS, allowing a user to register custom providers while its being built.  The behavior of the providers supported is defined by the JAX-RS Client API specification.  Below is a list of provider types expected to be supported by an implementation:
+
+=== ClientResponseFilter
+
+Filters of type `ClientResponseFilter` are invoked in order when a response is received from a remote service.
+
+=== ClientRequestFilter
+
+Filters of type `ClientRequestFilter` are invoked in order when a request is made to a remote service.
+
+=== MessageBodyReader
+
+The `MessageBodyReader` interface defined by JAX-RS allows the entity to be read from the API response after invocation.
+
+=== MessageBodyWriter
+
+The `MessageBodyWriter` interface defined by JAX-RS allows a request body to be written in the request for `@POST`, `@PUT` operations, as well as other HTTP methods that support bodies.
+
+=== ParamConverter
+
+The `ParamConverter` interface defined by JAX-RS allows a parameter in a resource method to be converted to a format to be used in a request or a response.
+
+=== ReaderInterceptor
+
+The `ReaderInterceptor` interface is a listener for when a read occurs against the response received from a remote service call.
+
+=== WriterInterceptor
+
+The `WriterInterceptor` interface is a listener for when a write occurs to the stream to be sent on the remote service invocation.
+
+== Provider Declaration
+
+In addition to defining providers via the client definition, interfaces may use the `@RegisterProviders` annotation to define classes to be registered as providers in addition to providers registered via the `RestClientBuilder`

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeSimpleGetOperationTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeSimpleGetOperationTest.java
@@ -16,17 +16,12 @@
 
 package org.eclipse.microprofile.rest.client.tck;
 
-import com.github.tomakehurst.wiremock.WireMockServer;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import javax.ws.rs.core.Response;
@@ -36,34 +31,14 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.testng.Assert.assertEquals;
 
-public class InvokeSimpleGetOperationTest extends Arquillian{
-    private static int port;
-    private WireMockServer wireMockServer;
-
+public class InvokeSimpleGetOperationTest extends WiremockArquillianTest{
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
             .addClass(SimpleGetApi.class)
             .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
-    }
-
-    @BeforeClass
-    public static void getPort() {
-        port = Integer.parseInt(System.getProperty("wiremock.server.port","8765"));
-    }
-
-    @BeforeMethod
-    public void setupMockServer() {
-        wireMockServer = new WireMockServer(options().port(port));
-        wireMockServer.start();
-    }
-
-    @AfterMethod
-    public void stopServer() {
-        wireMockServer.stop();
     }
 
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeWithBuiltProvidersTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeWithBuiltProvidersTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.tck.interfaces.InterfaceWithoutProvidersDefined;
+import org.eclipse.microprofile.rest.client.tck.providers.TestClientRequestFilter;
+import org.eclipse.microprofile.rest.client.tck.providers.TestClientResponseFilter;
+import org.eclipse.microprofile.rest.client.tck.providers.TestMessageBodyReader;
+import org.eclipse.microprofile.rest.client.tck.providers.TestMessageBodyWriter;
+import org.eclipse.microprofile.rest.client.tck.providers.TestParamConverterProvider;
+import org.eclipse.microprofile.rest.client.tck.providers.TestReaderInterceptor;
+import org.eclipse.microprofile.rest.client.tck.providers.TestWriterInterceptor;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.core.Response;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.testng.Assert.assertEquals;
+
+public class InvokeWithBuiltProvidersTest extends WiremockArquillianTest {
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class)
+            .addClass(InterfaceWithoutProvidersDefined.class)
+            .addPackage(TestClientResponseFilter.class.getPackage())
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    public void testInvokesPostOperation() throws Exception{
+        String inputBody = "input body will be removed";
+        String outputBody = "output body will be removed";
+        String expectedReceivedBody = "this is the replaced writer "+inputBody;
+        String expectedResponseBody = TestMessageBodyReader.REPLACED_BODY;
+        wireMockServer.stubFor(post(urlEqualTo("/"))
+            .willReturn(aResponse()
+                .withBody(outputBody)));
+
+        InterfaceWithoutProvidersDefined api = createClient();
+
+        Response response = api.executePost(inputBody);
+
+        String body = response.readEntity(String.class);
+
+        response.close();
+
+        assertEquals(body, expectedResponseBody);
+
+        wireMockServer.verify(1, postRequestedFor(urlEqualTo("/")).withRequestBody(equalTo(expectedReceivedBody)));
+
+        assertEquals(TestClientResponseFilter.getAndResetValue(),1);
+        assertEquals(TestClientRequestFilter.getAndResetValue(),1);
+        assertEquals(TestReaderInterceptor.getAndResetValue(),1);
+        assertEquals(TestWriterInterceptor.getAndResetValue(),1);
+    }
+
+    @Test
+    public void testInvokesPutOperation() throws Exception {
+        String inputBody = "input body will be removed";
+        String outputBody = "output body will be removed";
+        String expectedReceivedBody = "this is the replaced writer "+inputBody;
+        String expectedResponseBody = TestMessageBodyReader.REPLACED_BODY;
+        String id = "id";
+        String expectedId = "toStringid";
+        wireMockServer.stubFor(put(urlEqualTo("/"+expectedId))
+            .willReturn(aResponse()
+                .withBody(outputBody)));
+
+        InterfaceWithoutProvidersDefined api = createClient();
+
+        Response response = api.executePut(id, inputBody);
+
+        String body = response.readEntity(String.class);
+
+        response.close();
+
+        assertEquals(body, expectedResponseBody);
+
+        wireMockServer.verify(1, putRequestedFor(urlEqualTo("/"+expectedId)).withRequestBody(equalTo(expectedReceivedBody)));
+
+        assertEquals(TestClientResponseFilter.getAndResetValue(),1);
+        assertEquals(TestClientRequestFilter.getAndResetValue(),1);
+        assertEquals(TestReaderInterceptor.getAndResetValue(),1);
+        assertEquals(TestWriterInterceptor.getAndResetValue(),1);
+    }
+
+    private InterfaceWithoutProvidersDefined createClient() throws MalformedURLException{
+        return RestClientBuilder.newBuilder()
+            .register(TestClientRequestFilter.class)
+            .register(TestClientResponseFilter.class)
+            .register(TestMessageBodyReader.class)
+            .register(TestMessageBodyWriter.class)
+            .register(TestParamConverterProvider.class)
+            .register(TestReaderInterceptor.class)
+            .register(TestWriterInterceptor.class)
+            .baseUrl(new URL("http://localhost:"+ port))
+            .build(InterfaceWithoutProvidersDefined.class);
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeWithRegisteredProvidersTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeWithRegisteredProvidersTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.tck.interfaces.InterfaceWithProvidersDefined;
+import org.eclipse.microprofile.rest.client.tck.providers.TestClientRequestFilter;
+import org.eclipse.microprofile.rest.client.tck.providers.TestClientResponseFilter;
+import org.eclipse.microprofile.rest.client.tck.providers.TestMessageBodyReader;
+import org.eclipse.microprofile.rest.client.tck.providers.TestReaderInterceptor;
+import org.eclipse.microprofile.rest.client.tck.providers.TestWriterInterceptor;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.core.Response;
+import java.net.URL;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.testng.Assert.assertEquals;
+
+public class InvokeWithRegisteredProvidersTest extends WiremockArquillianTest {
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class)
+            .addClass(InterfaceWithProvidersDefined.class)
+            .addPackage(TestClientResponseFilter.class.getPackage())
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    public void testInvokesPostOperation() throws Exception{
+        String inputBody = "input body will be removed";
+        String outputBody = "output body will be removed";
+        String expectedReceivedBody = "this is the replaced writer "+inputBody;
+        String expectedResponseBody = TestMessageBodyReader.REPLACED_BODY;
+        wireMockServer.stubFor(post(urlEqualTo("/"))
+            .willReturn(aResponse()
+                .withBody(outputBody)));
+
+        InterfaceWithProvidersDefined api = RestClientBuilder.newBuilder()
+            .baseUrl(new URL("http://localhost:"+ port))
+            .build(InterfaceWithProvidersDefined.class);
+
+        Response response = api.executePost(inputBody);
+
+        String body = response.readEntity(String.class);
+
+        response.close();
+
+        assertEquals(body, expectedResponseBody);
+
+        wireMockServer.verify(1, postRequestedFor(urlEqualTo("/")).withRequestBody(equalTo(expectedReceivedBody)));
+
+        assertEquals(TestClientResponseFilter.getAndResetValue(),1);
+        assertEquals(TestClientRequestFilter.getAndResetValue(),1);
+        assertEquals(TestReaderInterceptor.getAndResetValue(),1);
+        assertEquals(TestWriterInterceptor.getAndResetValue(),1);
+    }
+
+    @Test
+    public void testInvokesPutOperation() throws Exception {
+        String inputBody = "input body will be removed";
+        String outputBody = "output body will be removed";
+        String expectedReceivedBody = "this is the replaced writer "+inputBody;
+        String expectedResponseBody = TestMessageBodyReader.REPLACED_BODY;
+        String id = "id";
+        String expectedId = "toStringid";
+        wireMockServer.stubFor(put(urlEqualTo("/"+expectedId))
+            .willReturn(aResponse()
+                .withBody(outputBody)));
+
+        InterfaceWithProvidersDefined api = RestClientBuilder.newBuilder()
+            .baseUrl(new URL("http://localhost:"+ port))
+            .build(InterfaceWithProvidersDefined.class);
+
+        Response response = api.executePut(id, inputBody);
+
+        String body = response.readEntity(String.class);
+
+        response.close();
+
+        assertEquals(body, expectedResponseBody);
+
+        wireMockServer.verify(1, putRequestedFor(urlEqualTo("/"+expectedId)).withRequestBody(equalTo(expectedReceivedBody)));
+
+        assertEquals(TestClientResponseFilter.getAndResetValue(),1);
+        assertEquals(TestClientRequestFilter.getAndResetValue(),1);
+        assertEquals(TestReaderInterceptor.getAndResetValue(),1);
+        assertEquals(TestWriterInterceptor.getAndResetValue(),1);
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/WiremockArquillianTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/WiremockArquillianTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import org.jboss.arquillian.testng.Arquillian;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+
+public abstract class WiremockArquillianTest extends Arquillian{
+    protected static int port;
+    protected WireMockServer wireMockServer;
+
+    @BeforeClass
+    public static void getPort() {
+        port = Integer.parseInt(System.getProperty("wiremock.server.port","8765"));
+    }
+
+    @BeforeMethod
+    public void setupMockServer() {
+        wireMockServer = new WireMockServer(options().port(port));
+        wireMockServer.start();
+    }
+
+    @AfterMethod
+    public void stopServer() {
+        wireMockServer.stop();
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/InterfaceWithProvidersDefined.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/InterfaceWithProvidersDefined.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterProviders;
+import org.eclipse.microprofile.rest.client.tck.providers.TestClientRequestFilter;
+import org.eclipse.microprofile.rest.client.tck.providers.TestClientResponseFilter;
+import org.eclipse.microprofile.rest.client.tck.providers.TestMessageBodyReader;
+import org.eclipse.microprofile.rest.client.tck.providers.TestMessageBodyWriter;
+import org.eclipse.microprofile.rest.client.tck.providers.TestParamConverterProvider;
+import org.eclipse.microprofile.rest.client.tck.providers.TestReaderInterceptor;
+import org.eclipse.microprofile.rest.client.tck.providers.TestWriterInterceptor;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/")
+@RegisterProviders({TestClientRequestFilter.class, TestClientResponseFilter.class, TestMessageBodyReader.class,
+    TestMessageBodyWriter.class, TestParamConverterProvider.class, TestReaderInterceptor.class, TestWriterInterceptor.class})
+@Produces(MediaType.TEXT_PLAIN)
+@Consumes(MediaType.TEXT_PLAIN)
+public interface InterfaceWithProvidersDefined {
+    @POST
+    Response executePost(String body);
+
+    @PUT
+    @Path("/{id}")
+    Response executePut(@PathParam("id") String id, String body);
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/InterfaceWithoutProvidersDefined.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/InterfaceWithoutProvidersDefined.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/")
+@Produces(MediaType.TEXT_PLAIN)
+@Consumes(MediaType.TEXT_PLAIN)
+public interface InterfaceWithoutProvidersDefined {
+    @POST
+    Response executePost(String body);
+
+    @PUT
+    @Path("/{id}")
+    Response executePut(@PathParam("id") String id, String body);
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TestClientRequestFilter.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TestClientRequestFilter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.providers;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TestClientRequestFilter implements ClientRequestFilter{
+    private static AtomicInteger invocations = new AtomicInteger(0);
+    @Override
+    public void filter(ClientRequestContext clientRequestContext) throws IOException {
+        invocations.incrementAndGet();
+    }
+
+    public static int getValue() {
+        return invocations.intValue();
+    }
+
+    public static int getAndResetValue() {
+        return invocations.getAndSet(0);
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TestClientResponseFilter.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TestClientResponseFilter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.providers;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientResponseContext;
+import javax.ws.rs.client.ClientResponseFilter;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TestClientResponseFilter implements ClientResponseFilter{
+    private static AtomicInteger invocations = new AtomicInteger(0);
+    @Override
+    public void filter(ClientRequestContext clientRequestContext, ClientResponseContext clientResponseContext) throws IOException {
+        invocations.incrementAndGet();
+    }
+
+    public static int getValue() {
+        return invocations.intValue();
+    }
+
+    public static int getAndResetValue() {
+        return invocations.getAndSet(0);
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TestMessageBodyReader.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TestMessageBodyReader.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.providers;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+public class TestMessageBodyReader implements MessageBodyReader<String> {
+
+    public static final String REPLACED_BODY = "this is the replaced body";
+
+    @Override
+    public boolean isReadable(Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType) {
+        return String.class.isAssignableFrom(aClass);
+    }
+
+    @Override
+    public String readFrom(Class<String> aClass, Type type, Annotation[] annotations, MediaType mediaType,
+                           MultivaluedMap<String, String> multivaluedMap, InputStream inputStream) throws IOException, WebApplicationException {
+        return REPLACED_BODY;
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TestMessageBodyWriter.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TestMessageBodyWriter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.providers;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+public class TestMessageBodyWriter implements MessageBodyWriter<String> {
+    @Override
+    public boolean isWriteable(Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType) {
+        return String.class.isAssignableFrom(aClass);
+    }
+
+    @Override
+    public long getSize(String s, Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType) {
+        return 0;
+    }
+
+    @Override
+    public void writeTo(String s, Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType,
+                        MultivaluedMap<String, Object> multivaluedMap, OutputStream outputStream) throws IOException, WebApplicationException {
+        outputStream.write("this is the replaced writer ".getBytes());
+        outputStream.write(s.getBytes());
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TestParamConverter.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TestParamConverter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.providers;
+
+import javax.ws.rs.ext.ParamConverter;
+
+public class TestParamConverter implements ParamConverter<String>{
+    @Override
+    public String fromString(String s) {
+        return "fromString"+s;
+    }
+
+    @Override
+    public String toString(String s) {
+        return "toString"+s;
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TestParamConverterProvider.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TestParamConverterProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.providers;
+
+import javax.ws.rs.ext.ParamConverter;
+import javax.ws.rs.ext.ParamConverterProvider;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+public class TestParamConverterProvider implements ParamConverterProvider {
+    @Override
+    public <T> ParamConverter<T> getConverter(Class<T> aClass, Type type, Annotation[] annotations) {
+        if(String.class.isAssignableFrom(aClass)) {
+            return (ParamConverter<T>) new TestParamConverter();
+        }
+        return null;
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TestReaderInterceptor.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TestReaderInterceptor.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.providers;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.ext.ReaderInterceptor;
+import javax.ws.rs.ext.ReaderInterceptorContext;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TestReaderInterceptor implements ReaderInterceptor{
+    private static AtomicInteger invocations = new AtomicInteger(0);
+    @Override
+    public Object aroundReadFrom(ReaderInterceptorContext readerInterceptorContext) throws IOException, WebApplicationException {
+        invocations.incrementAndGet();
+        return readerInterceptorContext.proceed();
+    }
+
+    public static int getValue() {
+        return invocations.intValue();
+    }
+
+    public static int getAndResetValue() {
+        return invocations.getAndSet(0);
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TestWriterInterceptor.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TestWriterInterceptor.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.providers;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.ext.WriterInterceptor;
+import javax.ws.rs.ext.WriterInterceptorContext;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TestWriterInterceptor implements WriterInterceptor {
+    private static AtomicInteger invocations = new AtomicInteger(0);
+    @Override
+    public void aroundWriteTo(WriterInterceptorContext writerInterceptorContext) throws IOException, WebApplicationException {
+        invocations.incrementAndGet();
+        writerInterceptorContext.proceed();
+    }
+
+    public static int getValue() {
+        return invocations.intValue();
+    }
+
+    public static int getAndResetValue() {
+        return invocations.getAndSet(0);
+    }
+}


### PR DESCRIPTION
Clarify how providers are registered, both via the builder API and at definition levels.  This currently covers the base providers available to a caller, which are known to work within the Client API.

This closes #7 

In addition, I'd like to get some input from @andymc12 , @reta and @sberyozkin on how true my claims about the client already supporting these providers is.