### PR TITLE
Adding CDI support, as well as MicroProfile Config support.

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/rest/client/inject/RegisterRestClient.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/inject/RegisterRestClient.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.inject;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A marker annotation to register a rest client at runtime.  This marker must be applied to any CDI managed
+ * clients.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface RegisterRestClient {
+}

--- a/api/src/main/java/org/eclipse/microprofile/rest/client/inject/RestClient.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/inject/RestClient.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.inject;
+
+import javax.enterprise.util.AnnotationLiteral;
+import javax.inject.Qualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Use the RestClient qualifier on an injection to point to indicate that this injection point is meant to use an instance
+ * of a Type-Safe Rest Client.
+ *
+ * <pre>
+ *     @Inject
+ *     @RestClient
+ *     private MyRemoteApi api;
+ * </pre>
+ *
+ * This will cause the injection point to be satisfied by the MicroProfile Rest Client runtime.
+ */
+@Qualifier
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RestClient {
+    RestClient LITERAL = new RestClientLiteral();
+
+    class RestClientLiteral extends AnnotationLiteral<RestClient> implements RestClient {
+
+    }
+}

--- a/spec/src/main/asciidoc/cdi.asciidoc
+++ b/spec/src/main/asciidoc/cdi.asciidoc
@@ -1,0 +1,49 @@
+//
+// Copyright (c) 2017 Contributors to the Eclipse Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+[[restcdi]]
+== MicroProfile Rest Client CDI Support
+
+Rest Client interfaces may be injected as CDI beans.  It is only required to support injection points that are defined by the application, programmatic lookup is not required to work.
+
+Interfaces are assumed to have a scope of `@Dependent` unless there is another scope defined on the interface.
+
+=== Support for MicroProfile Config
+
+For CDI defined interfaces, it is possible to use MicroProfile Config properties to define additional behaviors of the rest interface.  Assuming this interface:
+
+[source, java]
+----
+package com.mycompany.remoteServices;
+
+public interface MyServiceClient {
+    @GET
+    @Path("/greet")
+    Response greet();
+}
+----
+
+The values of the following properties will be provided via MicroProfile Config:
+
+- `com.mycompany.remoteServices.MyServiceClient/mp-rest/url`: The base URL to use for this service, the equivalent of the `baseUrl` method.  This property is considered required, however implementations may have other ways to define these URLs.
+- `com.mycompany.remoteServices.MyServiceClient/mp-rest/scope`: The fully qualified classname to a CDI scope to use for injection, defaults to `javax.enterprise.context.Dependent` as mentioned above.
+- `com.mycompany.remoteServices.MyServiceClient/mp-rest/providers`: A comma separated list of fully-qualified provider classnames to include in the client, the equivalent of the `register` method or the `@RegisterProviders` annotation.
+
+Implementations may support other custom properties registered in similar fashions or other ways.
+
+The `url` property must resolve to a value that can be parsed by the `URL` converter required by the MicroProfile Config spec.
+
+The `providers` property is not aggregated, the value will be read from the highest property `ConfigSource`

--- a/spec/src/main/asciidoc/cdi.asciidoc
+++ b/spec/src/main/asciidoc/cdi.asciidoc
@@ -17,12 +17,13 @@
 [[restcdi]]
 == MicroProfile Rest Client CDI Support
 
-Rest Client interfaces may be injected as CDI beans.  It is only required to support clients which have a `RestClient` qualifier on them.  Any injection point or programmatic look up that uses the qualifier `RestClient` is expected to be resolved by the MicroProfile Rest Client runtime.  Below is an example of said interface, with its matching injection point:
+Rest Client interfaces may be injected as CDI beans.  The runtime must create a CDI bean for each interface annotated with `RegisterRestClient`.  The bean created will include a qualifier `@RestClient` to differentiate the use as an API call against any other beans registered of the same type.  Based on the rules of how CDI resolves bean, you are only required to use the qualifier if you have multiple beans of the same type.  Any injection point or programmatic look up that uses the qualifier `RestClient` is expected to be resolved by the MicroProfile Rest Client runtime.  Below is an example of said interface, with its matching injection point:
 
 [source, java]
 ----
 package com.mycompany.remoteServices;
 
+@RegisterRestClient
 public interface MyServiceClient {
     @GET
     @Path("/greet")

--- a/spec/src/main/asciidoc/cdi.asciidoc
+++ b/spec/src/main/asciidoc/cdi.asciidoc
@@ -17,9 +17,44 @@
 [[restcdi]]
 == MicroProfile Rest Client CDI Support
 
-Rest Client interfaces may be injected as CDI beans.  It is only required to support injection points that are defined by the application, programmatic lookup is not required to work.
+Rest Client interfaces may be injected as CDI beans.  It is only required to support clients which have a `RestClient` qualifier on them.  Any injection point or programmatic look up that uses the qualifier `RestClient` is expected to be resolved by the MicroProfile Rest Client runtime.  Below is an example of said interface, with its matching injection point:
 
-Interfaces are assumed to have a scope of `@Dependent` unless there is another scope defined on the interface.
+[source, java]
+----
+package com.mycompany.remoteServices;
+
+public interface MyServiceClient {
+    @GET
+    @Path("/greet")
+    Response greet();
+}
+----
+
+[source, java]
+----
+@ApplicationScoped
+public class MyService {
+    @Inject
+    @RestClient
+    private MyServiceClient client;
+}
+----
+
+Likewise, a user can perform programmatic look up of the interface.  Here is one example, but any CDI look up should work:
+
+[source, java]
+----
+@ApplicationScoped
+public class MyService {
+    public void execute() {
+        MyServiceClient client = CDI.current().select(MyServiceClient.class, RestClient.LITERAL).get();
+    }
+}
+----
+
+The qualifier is used to differentiate use cases of the interface that are managed by this runtime, versus use cases that may be managed by other runtimes.
+
+Interfaces are assumed to have a scope of `@Dependent` unless there is another scope defined on the interface.  Implementations are expected to support all of the built in scopes for a bean.  Support for custom registered scopes should work, but is not guaranteed.
 
 === Support for MicroProfile Config
 

--- a/spec/src/main/asciidoc/microprofile-rest-client.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-rest-client.asciidoc
@@ -47,4 +47,6 @@ include::programmatic_lookup.asciidoc[]
 
 include::providers.asciidoc[]
 
+include::cdi.asciidoc[]
+
 include::release_notes.asciidoc[]

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/WiremockArquillianTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/WiremockArquillianTest.java
@@ -27,16 +27,24 @@ import org.testng.annotations.BeforeMethod;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 
 public abstract class WiremockArquillianTest extends Arquillian{
-    protected static int port;
-    protected WireMockServer wireMockServer;
+    static int port;
+    WireMockServer wireMockServer;
+
+    protected static int getPort() {
+        return port;
+    }
+
+    protected WireMockServer getWireMockServer() {
+        return wireMockServer;
+    }
 
     @BeforeClass
-    public static void getPort() {
+    public static void setupPort() {
         port = Integer.parseInt(System.getProperty("wiremock.server.port","8765"));
     }
 
     @BeforeMethod
-    public void setupMockServer() {
+    public void startMockServer() {
         wireMockServer = new WireMockServer(options().port(port));
         wireMockServer.start();
     }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/CDIInvokeSimpleGetOperationTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/CDIInvokeSimpleGetOperationTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.cditests;
+
+import org.eclipse.microprofile.rest.client.tck.WiremockArquillianTest;
+import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Inject;
+import javax.ws.rs.core.Response;
+import java.util.Set;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Verifies via CDI injection that you can use a programmatic interface.  verifies that the interface has Dependent scope.
+ */
+public class CDIInvokeSimpleGetOperationTest extends WiremockArquillianTest{
+    @Inject
+    private SimpleGetApi api;
+    @Inject
+    private BeanManager beanManager;
+    @Deployment
+    public static WebArchive createDeployment() {
+        String propertyName = SimpleGetApi.class.getName()+"/mp-rest/url";
+        String value = "http://localhost:"+ getPort();
+        return ShrinkWrap.create(WebArchive.class)
+            .addClass(SimpleGetApi.class)
+            .addAsManifestResource(new StringAsset(propertyName+"="+value), "microprofile-config.properties")
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    public void testInvokesOperation() throws Exception{
+        String expectedBody = "Hello, MicroProfile!";
+        getWireMockServer().stubFor(get(urlEqualTo("/"))
+            .willReturn(aResponse()
+                .withBody(expectedBody)));
+
+        Response response = api.executeGet();
+
+        String body = response.readEntity(String.class);
+
+        response.close();
+
+        assertEquals(body, expectedBody);
+
+        getWireMockServer().verify(1, getRequestedFor(urlEqualTo("/")));
+    }
+
+    @Test
+    public void testHasDependentScopedByDefault() {
+        Set<Bean<?>> beans = beanManager.getBeans(SimpleGetApi.class);
+        Bean<?> resolved = beanManager.resolve(beans);
+        assertEquals(resolved.getScope(), Dependent.class);
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/CDIInvokeSimpleGetOperationTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/CDIInvokeSimpleGetOperationTest.java
@@ -18,6 +18,7 @@
 
 package org.eclipse.microprofile.rest.client.tck.cditests;
 
+import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.eclipse.microprofile.rest.client.tck.WiremockArquillianTest;
 import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -45,6 +46,7 @@ import static org.testng.Assert.assertEquals;
  */
 public class CDIInvokeSimpleGetOperationTest extends WiremockArquillianTest{
     @Inject
+    @RestClient
     private SimpleGetApi api;
     @Inject
     private BeanManager beanManager;
@@ -76,9 +78,12 @@ public class CDIInvokeSimpleGetOperationTest extends WiremockArquillianTest{
         getWireMockServer().verify(1, getRequestedFor(urlEqualTo("/")));
     }
 
+    /**
+     * Tests that the component injected has Dependent scope
+     */
     @Test
     public void testHasDependentScopedByDefault() {
-        Set<Bean<?>> beans = beanManager.getBeans(SimpleGetApi.class);
+        Set<Bean<?>> beans = beanManager.getBeans(SimpleGetApi.class, RestClient.LITERAL);
         Bean<?> resolved = beanManager.resolve(beans);
         assertEquals(resolved.getScope(), Dependent.class);
     }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/CDIInvokeWithRegisteredProvidersTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/CDIInvokeWithRegisteredProvidersTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.cditests;
+
+import org.eclipse.microprofile.rest.client.tck.WiremockArquillianTest;
+import org.eclipse.microprofile.rest.client.tck.interfaces.InterfaceWithProvidersDefined;
+import org.eclipse.microprofile.rest.client.tck.providers.TestClientRequestFilter;
+import org.eclipse.microprofile.rest.client.tck.providers.TestClientResponseFilter;
+import org.eclipse.microprofile.rest.client.tck.providers.TestMessageBodyReader;
+import org.eclipse.microprofile.rest.client.tck.providers.TestReaderInterceptor;
+import org.eclipse.microprofile.rest.client.tck.providers.TestWriterInterceptor;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.Response;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Verifies via CDI injection that you can use a programmatic interface.  Verifies that the interface includes registered providers.
+ */
+public class CDIInvokeWithRegisteredProvidersTest extends WiremockArquillianTest {
+    @Inject
+    private InterfaceWithProvidersDefined api;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        String propertyName = InterfaceWithProvidersDefined.class.getName()+"/mp-rest/url";
+        String value = "http://localhost:"+ getPort();
+        return ShrinkWrap.create(WebArchive.class)
+            .addClass(InterfaceWithProvidersDefined.class)
+            .addPackage(TestClientResponseFilter.class.getPackage())
+            .addAsManifestResource(new StringAsset(propertyName+"="+value), "microprofile-config.properties")
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    public void testInvokesPostOperation() throws Exception{
+        String inputBody = "input body will be removed";
+        String outputBody = "output body will be removed";
+        String expectedReceivedBody = "this is the replaced writer "+inputBody;
+        String expectedResponseBody = TestMessageBodyReader.REPLACED_BODY;
+        getWireMockServer().stubFor(post(urlEqualTo("/"))
+            .willReturn(aResponse()
+                .withBody(outputBody)));
+
+        Response response = api.executePost(inputBody);
+
+        String body = response.readEntity(String.class);
+
+        response.close();
+
+        assertEquals(body, expectedResponseBody);
+
+        getWireMockServer().verify(1, postRequestedFor(urlEqualTo("/")).withRequestBody(equalTo(expectedReceivedBody)));
+
+        assertEquals(TestClientResponseFilter.getAndResetValue(),1);
+        assertEquals(TestClientRequestFilter.getAndResetValue(),1);
+        assertEquals(TestReaderInterceptor.getAndResetValue(),1);
+        assertEquals(TestWriterInterceptor.getAndResetValue(),1);
+    }
+
+    @Test
+    public void testInvokesPutOperation() throws Exception {
+        String inputBody = "input body will be removed";
+        String outputBody = "output body will be removed";
+        String expectedReceivedBody = "this is the replaced writer "+inputBody;
+        String expectedResponseBody = TestMessageBodyReader.REPLACED_BODY;
+        String id = "id";
+        String expectedId = "toStringid";
+        getWireMockServer().stubFor(put(urlEqualTo("/"+expectedId))
+            .willReturn(aResponse()
+                .withBody(outputBody)));
+
+        Response response = api.executePut(id, inputBody);
+
+        String body = response.readEntity(String.class);
+
+        response.close();
+
+        assertEquals(body, expectedResponseBody);
+
+        getWireMockServer().verify(1, putRequestedFor(urlEqualTo("/"+expectedId)).withRequestBody(equalTo(expectedReceivedBody)));
+
+        assertEquals(TestClientResponseFilter.getAndResetValue(),1);
+        assertEquals(TestClientRequestFilter.getAndResetValue(),1);
+        assertEquals(TestReaderInterceptor.getAndResetValue(),1);
+        assertEquals(TestWriterInterceptor.getAndResetValue(),1);
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/CDIInvokeWithRegisteredProvidersTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/CDIInvokeWithRegisteredProvidersTest.java
@@ -18,6 +18,7 @@
 
 package org.eclipse.microprofile.rest.client.tck.cditests;
 
+import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.eclipse.microprofile.rest.client.tck.WiremockArquillianTest;
 import org.eclipse.microprofile.rest.client.tck.interfaces.InterfaceWithProvidersDefined;
 import org.eclipse.microprofile.rest.client.tck.providers.TestClientRequestFilter;
@@ -49,6 +50,7 @@ import static org.testng.Assert.assertEquals;
  */
 public class CDIInvokeWithRegisteredProvidersTest extends WiremockArquillianTest {
     @Inject
+    @RestClient
     private InterfaceWithProvidersDefined api;
 
     @Deployment

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasAppScopeTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasAppScopeTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.cditests;
+
+import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+import java.util.Set;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * This test verifies that you can configure a bean of ApplicationScoped, as well as have the scope on an interface.
+ */
+public class HasAppScopeTest extends Arquillian {
+    @Inject
+    private BeanManager beanManager;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        String url = SimpleGetApi.class.getName() + "/mp-rest/url=http://localhost:8080";
+        String url2 = MyAppScopedApi.class.getName() + "/mp-rest/url=http://localhost:8080";
+        String scope = SimpleGetApi.class.getName() + "/mp-rest/scope=" + ApplicationScoped.class.getName();
+        return ShrinkWrap.create(WebArchive.class)
+            .addClasses(SimpleGetApi.class, MyAppScopedApi.class)
+            .addAsManifestResource(new StringAsset(url + "\n" + scope + "\n"+ url2), "microprofile-config.properties")
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    public void testHasApplicationScoped() {
+        Set<Bean<?>> beans = beanManager.getBeans(SimpleGetApi.class);
+        Bean<?> resolved = beanManager.resolve(beans);
+        assertEquals(resolved.getScope(), ApplicationScoped.class);
+    }
+
+    @Test
+    public void testHasApplicationScopedWhenAnnotated() {
+        Set<Bean<?>> beans = beanManager.getBeans(MyAppScopedApi.class);
+        Bean<?> resolved = beanManager.resolve(beans);
+        assertEquals(resolved.getScope(), ApplicationScoped.class);
+    }
+
+    @ApplicationScoped
+    @Path("/")
+    public interface MyAppScopedApi {
+        @GET
+        public Response get();
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasAppScopeTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasAppScopeTest.java
@@ -18,6 +18,7 @@
 
 package org.eclipse.microprofile.rest.client.tck.cditests;
 
+import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -58,14 +59,14 @@ public class HasAppScopeTest extends Arquillian {
 
     @Test
     public void testHasApplicationScoped() {
-        Set<Bean<?>> beans = beanManager.getBeans(SimpleGetApi.class);
+        Set<Bean<?>> beans = beanManager.getBeans(SimpleGetApi.class, RestClient.LITERAL);
         Bean<?> resolved = beanManager.resolve(beans);
         assertEquals(resolved.getScope(), ApplicationScoped.class);
     }
 
     @Test
     public void testHasApplicationScopedWhenAnnotated() {
-        Set<Bean<?>> beans = beanManager.getBeans(MyAppScopedApi.class);
+        Set<Bean<?>> beans = beanManager.getBeans(MyAppScopedApi.class, RestClient.LITERAL);
         Bean<?> resolved = beanManager.resolve(beans);
         assertEquals(resolved.getScope(), ApplicationScoped.class);
     }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasConversationScopeTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasConversationScopeTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.cditests;
+
+import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+import javax.enterprise.context.ConversationScoped;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+import java.util.Set;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * This test verifies that you can configure a bean of ConversationScoped, as well as have the scope on an interface.
+ */
+public class HasConversationScopeTest extends Arquillian {
+    @Inject
+    private BeanManager beanManager;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        String url = SimpleGetApi.class.getName() + "/mp-rest/url=http://localhost:8080";
+        String url2 = MyConversationScopedApi.class.getName() + "/mp-rest/url=http://localhost:8080";
+        String scope = SimpleGetApi.class.getName() + "/mp-rest/scope=" + ConversationScoped.class.getName();
+        return ShrinkWrap.create(WebArchive.class)
+            .addClasses(SimpleGetApi.class, MyConversationScopedApi.class)
+            .addAsManifestResource(new StringAsset(url + "\n" + scope + "\n" + url2), "microprofile-config.properties")
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    public void testHasConversationScoped() {
+        Set<Bean<?>> beans = beanManager.getBeans(SimpleGetApi.class);
+        Bean<?> resolved = beanManager.resolve(beans);
+        assertEquals(resolved.getScope(), ConversationScoped.class);
+    }
+
+    @Test
+    public void testHasConversationScopedWhenAnnotated() {
+        Set<Bean<?>> beans = beanManager.getBeans(MyConversationScopedApi.class);
+        Bean<?> resolved = beanManager.resolve(beans);
+        assertEquals(resolved.getScope(), ConversationScoped.class);
+    }
+
+    @Path("/")
+    @ConversationScoped
+    public interface MyConversationScopedApi {
+        @GET
+        public Response get();
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasConversationScopeTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasConversationScopeTest.java
@@ -18,6 +18,7 @@
 
 package org.eclipse.microprofile.rest.client.tck.cditests;
 
+import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -58,14 +59,14 @@ public class HasConversationScopeTest extends Arquillian {
 
     @Test
     public void testHasConversationScoped() {
-        Set<Bean<?>> beans = beanManager.getBeans(SimpleGetApi.class);
+        Set<Bean<?>> beans = beanManager.getBeans(SimpleGetApi.class, RestClient.LITERAL);
         Bean<?> resolved = beanManager.resolve(beans);
         assertEquals(resolved.getScope(), ConversationScoped.class);
     }
 
     @Test
     public void testHasConversationScopedWhenAnnotated() {
-        Set<Bean<?>> beans = beanManager.getBeans(MyConversationScopedApi.class);
+        Set<Bean<?>> beans = beanManager.getBeans(MyConversationScopedApi.class, RestClient.LITERAL);
         Bean<?> resolved = beanManager.resolve(beans);
         assertEquals(resolved.getScope(), ConversationScoped.class);
     }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasRequestScopeTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasRequestScopeTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.cditests;
+
+import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.core.Response;
+import java.util.Set;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * This test verifies that you can configure a bean of RequestScoped, as well as have the scope on an interface.
+ */
+public class HasRequestScopeTest extends Arquillian {
+    @Inject
+    private BeanManager beanManager;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        String url = SimpleGetApi.class.getName() + "/mp-rest/url=http://localhost:8080";
+        String url2 = MyRequestScopedApi.class.getName() + "/mp-rest/url=http://localhost:8080";
+        String scope = SimpleGetApi.class.getName() + "/mp-rest/scope=" + RequestScoped.class.getName();
+        return ShrinkWrap.create(WebArchive.class)
+            .addClasses(SimpleGetApi.class, MyRequestScopedApi.class)
+            .addAsManifestResource(new StringAsset(url + "\n" + scope + "\n" + url2), "microprofile-config.properties")
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    public void testHasRequestScoped() {
+        Set<Bean<?>> beans = beanManager.getBeans(SimpleGetApi.class);
+        Bean<?> resolved = beanManager.resolve(beans);
+        assertEquals(resolved.getScope(), RequestScoped.class);
+    }
+
+    @Test
+    public void testHasRequestScopedWhenAnnotated() {
+        Set<Bean<?>> beans = beanManager.getBeans(MyRequestScopedApi.class);
+        Bean<?> resolved = beanManager.resolve(beans);
+        assertEquals(resolved.getScope(), RequestScoped.class);
+    }
+
+    @RequestScoped
+    public interface MyRequestScopedApi {
+        @GET
+        public Response get();
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasRequestScopeTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasRequestScopeTest.java
@@ -18,6 +18,7 @@
 
 package org.eclipse.microprofile.rest.client.tck.cditests;
 
+import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -57,14 +58,14 @@ public class HasRequestScopeTest extends Arquillian {
 
     @Test
     public void testHasRequestScoped() {
-        Set<Bean<?>> beans = beanManager.getBeans(SimpleGetApi.class);
+        Set<Bean<?>> beans = beanManager.getBeans(SimpleGetApi.class, RestClient.LITERAL);
         Bean<?> resolved = beanManager.resolve(beans);
         assertEquals(resolved.getScope(), RequestScoped.class);
     }
 
     @Test
     public void testHasRequestScopedWhenAnnotated() {
-        Set<Bean<?>> beans = beanManager.getBeans(MyRequestScopedApi.class);
+        Set<Bean<?>> beans = beanManager.getBeans(MyRequestScopedApi.class, RestClient.LITERAL);
         Bean<?> resolved = beanManager.resolve(beans);
         assertEquals(resolved.getScope(), RequestScoped.class);
     }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasSessionScopeTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasSessionScopeTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.cditests;
+
+import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+import javax.enterprise.context.SessionScoped;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+import java.util.Set;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * This test verifies that you can configure a bean of SessionScoped, as well as have the scope on an interface.
+ */
+public class HasSessionScopeTest extends Arquillian{
+    @Inject
+    private BeanManager beanManager;
+    @Deployment
+    public static WebArchive createDeployment() {
+        String url = SimpleGetApi.class.getName()+"/mp-rest/url=http://localhost:8080";
+        String url2 = MySessionScopedApi.class.getName()+"/mp-rest/url=http://localhost:8080";
+        String scope = SimpleGetApi.class.getName()+"/mp-rest/scope="+ SessionScoped.class.getName();
+        return ShrinkWrap.create(WebArchive.class)
+            .addClasses(SimpleGetApi.class, MySessionScopedApi.class)
+            .addAsManifestResource(new StringAsset(url+"\n"+scope), "microprofile-config.properties")
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+    @Test
+    public void testHasSingletonScoped() {
+        Set<Bean<?>> beans = beanManager.getBeans(SimpleGetApi.class);
+        Bean<?> resolved = beanManager.resolve(beans);
+        assertEquals(resolved.getScope(), SessionScoped.class);
+    }
+
+    @Test
+    public void testHasSessionScopedWhenAnnotated() {
+        Set<Bean<?>> beans = beanManager.getBeans(MySessionScopedApi.class);
+        Bean<?> resolved = beanManager.resolve(beans);
+        assertEquals(resolved.getScope(), SessionScoped.class);
+    }
+
+    @SessionScoped
+    @Path("/")
+    public interface MySessionScopedApi {
+        @GET
+        public Response get();
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasSessionScopeTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasSessionScopeTest.java
@@ -18,6 +18,7 @@
 
 package org.eclipse.microprofile.rest.client.tck.cditests;
 
+import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -56,14 +57,14 @@ public class HasSessionScopeTest extends Arquillian{
     }
     @Test
     public void testHasSingletonScoped() {
-        Set<Bean<?>> beans = beanManager.getBeans(SimpleGetApi.class);
+        Set<Bean<?>> beans = beanManager.getBeans(SimpleGetApi.class, RestClient.LITERAL);
         Bean<?> resolved = beanManager.resolve(beans);
         assertEquals(resolved.getScope(), SessionScoped.class);
     }
 
     @Test
     public void testHasSessionScopedWhenAnnotated() {
-        Set<Bean<?>> beans = beanManager.getBeans(MySessionScopedApi.class);
+        Set<Bean<?>> beans = beanManager.getBeans(MySessionScopedApi.class, RestClient.LITERAL);
         Bean<?> resolved = beanManager.resolve(beans);
         assertEquals(resolved.getScope(), SessionScoped.class);
     }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasSingletonScopeTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasSingletonScopeTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.cditests;
+
+import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+import java.util.Set;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * This test verifies that you can configure a bean of Singleton scope, as well as have the scope on an interface.
+ */
+public class HasSingletonScopeTest extends Arquillian {
+    @Inject
+    private BeanManager beanManager;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        String url = SimpleGetApi.class.getName() + "/mp-rest/url=http://localhost:8080";
+        String url2 = MySingletonApi.class.getName() + "/mp-rest/url=http://localhost:8080";
+        String scope = SimpleGetApi.class.getName() + "/mp-rest/scope=" + Singleton.class.getName();
+        return ShrinkWrap.create(WebArchive.class)
+            .addClasses(SimpleGetApi.class, MySingletonApi.class)
+            .addAsManifestResource(new StringAsset(url + "\n" + scope), "microprofile-config.properties")
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    public void testHasSingletonScoped() {
+        Set<Bean<?>> beans = beanManager.getBeans(SimpleGetApi.class);
+        Bean<?> resolved = beanManager.resolve(beans);
+        assertEquals(resolved.getScope(), Singleton.class);
+    }
+
+    @Test
+    public void testHasSingletonScopedWhenAnnotated() {
+        Set<Bean<?>> beans = beanManager.getBeans(MySingletonApi.class);
+        Bean<?> resolved = beanManager.resolve(beans);
+        assertEquals(resolved.getScope(), MySingletonApi.class);
+    }
+
+    @Path("/")
+    @Singleton
+    public interface MySingletonApi {
+        @GET
+        public Response get();
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasSingletonScopeTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasSingletonScopeTest.java
@@ -18,6 +18,7 @@
 
 package org.eclipse.microprofile.rest.client.tck.cditests;
 
+import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -58,14 +59,14 @@ public class HasSingletonScopeTest extends Arquillian {
 
     @Test
     public void testHasSingletonScoped() {
-        Set<Bean<?>> beans = beanManager.getBeans(SimpleGetApi.class);
+        Set<Bean<?>> beans = beanManager.getBeans(SimpleGetApi.class, RestClient.LITERAL);
         Bean<?> resolved = beanManager.resolve(beans);
         assertEquals(resolved.getScope(), Singleton.class);
     }
 
     @Test
     public void testHasSingletonScopedWhenAnnotated() {
-        Set<Bean<?>> beans = beanManager.getBeans(MySingletonApi.class);
+        Set<Bean<?>> beans = beanManager.getBeans(MySingletonApi.class, RestClient.LITERAL);
         Bean<?> resolved = beanManager.resolve(beans);
         assertEquals(resolved.getScope(), MySingletonApi.class);
     }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/InterfaceWithProvidersDefined.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/InterfaceWithProvidersDefined.java
@@ -19,6 +19,7 @@
 package org.eclipse.microprofile.rest.client.tck.interfaces;
 
 import org.eclipse.microprofile.rest.client.annotation.RegisterProviders;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.eclipse.microprofile.rest.client.tck.providers.TestClientRequestFilter;
 import org.eclipse.microprofile.rest.client.tck.providers.TestClientResponseFilter;
 import org.eclipse.microprofile.rest.client.tck.providers.TestMessageBodyReader;
@@ -41,6 +42,7 @@ import javax.ws.rs.core.Response;
     TestMessageBodyWriter.class, TestParamConverterProvider.class, TestReaderInterceptor.class, TestWriterInterceptor.class})
 @Produces(MediaType.TEXT_PLAIN)
 @Consumes(MediaType.TEXT_PLAIN)
+@RegisterRestClient
 public interface InterfaceWithProvidersDefined {
     @POST
     Response executePost(String body);

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/SimpleGetApi.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/SimpleGetApi.java
@@ -16,11 +16,13 @@
 
 package org.eclipse.microprofile.rest.client.tck.interfaces;
 
+import javax.enterprise.context.Dependent;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 
 @Path("/")
+@Dependent
 public interface SimpleGetApi {
     @GET
     Response executeGet();

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/SimpleGetApi.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/SimpleGetApi.java
@@ -16,6 +16,8 @@
 
 package org.eclipse.microprofile.rest.client.tck.interfaces;
 
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
 import javax.enterprise.context.Dependent;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -23,6 +25,7 @@ import javax.ws.rs.core.Response;
 
 @Path("/")
 @Dependent
+@RegisterRestClient
 public interface SimpleGetApi {
     @GET
     Response executeGet();


### PR DESCRIPTION
This closes #3 & #4 

I went ahead and combined these two tickets.  There were two reasons for it:

- I didn't want to introduce a hard coded way to have a URL set, it should always be configured.
- Most of the configuration defined is optional, since they can be defined directly on the interface.

Any thoughts on this approach @andymc12 or @reta ?