### PR TITLE
Make RestClientBuilder an interface instead of an abstract class

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
@@ -26,24 +26,17 @@ import java.util.function.ToIntFunction;
 
 /**
  * <p>
- * This is the main entry point for creating a Type Safe Rest Client.
- * Implementations are expected to implement this class and register a service
- * provider via {@link ServiceLoader} that works within their implementation.
+ * This is the main entry point for creating a Type Safe Rest Client.  Implementations are expected
+ * to implement this class and register a service provider via {@link ServiceLoader} that works within their implementation.
  * <p>
- * Invoking
- * <pre>RestClientBuilder.newBuilder()</pre> is intended to always create a new
- * instance, not use a cached version.
+ * Invoking <pre>RestClientBuilder.newBuilder()</pre> is intended to always create a new instance, not use a cached version.
  * <p>
- * If multiple implementations of RestClientBuilder are discovered, the one with
- * the highest value of the {@link Priority} annotation is used
+ * If multiple implementations of RestClientBuilder are discovered, the one with the highest value of the {@link Priority} annotation is used
  * <p>
- * The {@link ServiceLoader} will first search via the current Thread's Context
- * ClassLoader, then {@link RestClientBuilder}'s {@link ClassLoader}
+ * The {@link ServiceLoader} will first search via the current Thread's Context ClassLoader, then {@link RestClientBuilder}'s {@link ClassLoader}
  * <p>
- * The
- * <pre>RestClientBuilder</pre> is a {@link Configurable} class as defined by
- * JAX-RS. This allows a user to register providers, implementation specific
- * configuration.
+ * The <pre>RestClientBuilder</pre> is a {@link Configurable} class as defined by JAX-RS.  This allows a user to register providers,
+ * implementation specific configuration.
  */
 public interface RestClientBuilder extends Configurable<RestClientBuilder> {
 
@@ -62,31 +55,21 @@ public interface RestClientBuilder extends Configurable<RestClientBuilder> {
     }
 
     /**
-     * Specifies the base URL to be used when making requests. Assuming that the
-     * interface has a
-     * <pre>@Path("/api")</pre> at the interface level and a
-     * <pre>url</pre> is given with
-     * <pre>http://my-service:8080/service</pre> then all REST calls will be
-     * invoked with a
-     * <pre>url</pre> of
-     * <pre>http://my-service:8080/service/api</pre> in addition to any
-     * <pre>@Path</pre> annotations included on the method.
-     *
+     * Specifies the base URL to be used when making requests.  Assuming that the interface has a <pre>@Path("/api")</pre> at the interface level
+     * and a <pre>url</pre> is given with <pre>http://my-service:8080/service</pre> then all REST calls will be invoked with a <pre>url</pre> of
+     * <pre>http://my-service:8080/service/api</pre> in addition to any <pre>@Path</pre> annotations included on the method.
      * @param url the base Url for the service.
      * @return the current builder with the baseUrl set
      */
     public abstract RestClientBuilder baseUrl(URL url);
 
     /**
-     * Based on the configured RestClientBuilder, creates a new instance of the
-     * given REST interface to invoke API calls against.
-     *
+     * Based on the configured RestClientBuilder, creates a new instance of the given REST interface to invoke API calls against.
      * @param clazz the interface that defines REST API methods for use
      * @param <T> the type of the interface
      * @return a new instance of an implementation of this REST interface that
-     * @throws IllegalStateException if not all pre-requisites are satisfied for
-     * the builder, this exception may get thrown. For instance, if a URL has
-     * not been set.
+     * @throws IllegalStateException if not all pre-requisites are satisfied for the builder, this exception may get thrown.  For instance, if a URL
+     *  has not been set.
      */
     public abstract <T> T build(Class<T> clazz) throws IllegalStateException;
 

--- a/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
@@ -86,7 +86,7 @@ class PrivateRestClientBuilder {
             Priority priority = value.getClass().getAnnotation(Priority.class);
             if (priority == null) {
                 return 1;
-            } 
+            }
             else {
                 return priority.value();
             }

--- a/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.eclipse.microprofile.rest.client;
 
 import javax.annotation.Priority;
@@ -27,19 +26,27 @@ import java.util.function.ToIntFunction;
 
 /**
  * <p>
- * This is the main entry point for creating a Type Safe Rest Client.  Implementations are expected
- * to implement this class and register a service provider via {@link ServiceLoader} that works within their implementation.
+ * This is the main entry point for creating a Type Safe Rest Client.
+ * Implementations are expected to implement this class and register a service
+ * provider via {@link ServiceLoader} that works within their implementation.
  * <p>
- * Invoking <pre>RestClientBuilder.newBuilder()</pre> is intended to always create a new instance, not use a cached version.
+ * Invoking
+ * <pre>RestClientBuilder.newBuilder()</pre> is intended to always create a new
+ * instance, not use a cached version.
  * <p>
- * If multiple implementations of RestClientBuilder are discovered, the one with the highest value of the {@link Priority} annotation is used
+ * If multiple implementations of RestClientBuilder are discovered, the one with
+ * the highest value of the {@link Priority} annotation is used
  * <p>
- * The {@link ServiceLoader} will first search via the current Thread's Context ClassLoader, then {@link RestClientBuilder}'s {@link ClassLoader}
+ * The {@link ServiceLoader} will first search via the current Thread's Context
+ * ClassLoader, then {@link RestClientBuilder}'s {@link ClassLoader}
  * <p>
- * The <pre>RestClientBuilder</pre> is a {@link Configurable} class as defined by JAX-RS.  This allows a user to register providers,
- * implementation specific configuration.
+ * The
+ * <pre>RestClientBuilder</pre> is a {@link Configurable} class as defined by
+ * JAX-RS. This allows a user to register providers, implementation specific
+ * configuration.
  */
-public abstract class RestClientBuilder implements Configurable<RestClientBuilder>{
+public interface RestClientBuilder extends Configurable<RestClientBuilder> {
+
     public static RestClientBuilder newBuilder() {
         ServiceLoader<RestClientBuilder> loader = ServiceLoader.load(RestClientBuilder.class);
         List<RestClientBuilder> clientBuilders = new ArrayList<>();
@@ -47,38 +54,56 @@ public abstract class RestClientBuilder implements Configurable<RestClientBuilde
         loader = ServiceLoader.load(RestClientBuilder.class, RestClientBuilder.class.getClassLoader());
         loader.forEach(clientBuilders::add);
 
-        if(clientBuilders.size() == 0) {
-            throw new RuntimeException("No implementation of '"+RestClientBuilder.class.getSimpleName()+"' found");
+        if (clientBuilders.size() == 0) {
+            throw new RuntimeException("No implementation of '" + RestClientBuilder.class.getSimpleName() + "' found");
         }
-        clientBuilders.sort(Comparator.comparingInt(priorityComparator()).reversed());
+        clientBuilders.sort(Comparator.comparingInt(PrivateRestClientBuilder.priorityComparator()).reversed());
         return clientBuilders.get(0);
     }
 
     /**
-     * Specifies the base URL to be used when making requests.  Assuming that the interface has a <pre>@Path("/api")</pre> at the interface level
-     * and a <pre>url</pre> is given with <pre>http://my-service:8080/service</pre> then all REST calls will be invoked with a <pre>url</pre> of
-     * <pre>http://my-service:8080/service/api</pre> in addition to any <pre>@Path</pre> annotations included on the method.
+     * Specifies the base URL to be used when making requests. Assuming that the
+     * interface has a
+     * <pre>@Path("/api")</pre> at the interface level and a
+     * <pre>url</pre> is given with
+     * <pre>http://my-service:8080/service</pre> then all REST calls will be
+     * invoked with a
+     * <pre>url</pre> of
+     * <pre>http://my-service:8080/service/api</pre> in addition to any
+     * <pre>@Path</pre> annotations included on the method.
+     *
      * @param url the base Url for the service.
      * @return the current builder with the baseUrl set
      */
     public abstract RestClientBuilder baseUrl(URL url);
 
     /**
-     * Based on the configured RestClientBuilder, creates a new instance of the given REST interface to invoke API calls against.
+     * Based on the configured RestClientBuilder, creates a new instance of the
+     * given REST interface to invoke API calls against.
+     *
      * @param clazz the interface that defines REST API methods for use
      * @param <T> the type of the interface
      * @return a new instance of an implementation of this REST interface that
-     * @throws IllegalStateException if not all pre-requisites are satisfied for the builder, this exception may get thrown.  For instance, if a URL
-     *  has not been set.
+     * @throws IllegalStateException if not all pre-requisites are satisfied for
+     * the builder, this exception may get thrown. For instance, if a URL has
+     * not been set.
      */
     public abstract <T> T build(Class<T> clazz) throws IllegalStateException;
 
-    private static ToIntFunction<Object> priorityComparator() {
+}
+
+class PrivateRestClientBuilder {
+    
+    private PrivateRestClientBuilder() {
+        // shouldn't be instantiated
+    }
+
+    static ToIntFunction<Object> priorityComparator() {
         return value -> {
             Priority priority = value.getClass().getAnnotation(Priority.class);
             if (priority == null) {
                 return 1;
-            }
+            } 
             else {
                 return priority.value();
             }

--- a/api/src/test/java/org/eclipse/microprofile/rest/client/AbstractBuilder.java
+++ b/api/src/test/java/org/eclipse/microprofile/rest/client/AbstractBuilder.java
@@ -22,7 +22,7 @@ import javax.ws.rs.core.Configurable;
 import javax.ws.rs.core.Configuration;
 import java.util.Map;
 
-public abstract class AbstractBuilder extends RestClientBuilder implements Configurable<RestClientBuilder> {
+public abstract class AbstractBuilder implements RestClientBuilder, Configurable<RestClientBuilder> {
     @Override
     public Configuration getConfiguration() {
         return null;


### PR DESCRIPTION
RestClientBuilder would work equally well as an interface instead of abstract class. An abstract class forces inheritance and isn't necessary since we can use Java 8 default methods to add default behavior if needed. Private code is in package visible static helper class.