### PR TITLE
Registering a JSON-P Provider - #26

### DIFF
--- a/spec/src/main/asciidoc/providers.asciidoc
+++ b/spec/src/main/asciidoc/providers.asciidoc
@@ -92,13 +92,14 @@ In addition to defining providers via the client definition, interfaces may use 
 
 == Automatic Provider Registration
 
-Implementations may provider any number of providers registered automatically, but t
+Implementations may provide any number of providers registered automatically, but t
 
 === JSON-P Provider
 
 When an interface is registered that contains:
-- `@Produces("\*/json")` or
-- `@Consumes("\*/json")` or
+
+- `@Produces("*/json")` or
+- `@Consumes("*/json")` or
 - a method that declares input or output of type `javax.json.JsonValue` or any subclass therein
 
 Then a JSON-P `MessageBodyReader` and `MessageBodyWriter` will be registered automatically by the implementation.  This is in alignment with the JAX-RS 2.0 specification.  The provider registered will have a priority of `Integer.MAX_VALUE`, allowing a user to register a custom provider to be used instead.

--- a/spec/src/main/asciidoc/providers.asciidoc
+++ b/spec/src/main/asciidoc/providers.asciidoc
@@ -86,14 +86,49 @@ In this case, if the `get` method results in an exception (response status code 
 
 Any methods that read the response body as a stream must ensure that they reset the stream.
 
-==== Built in ResponseExceptionMapper
+== Provider Declaration
+
+In addition to defining providers via the client definition, interfaces may use the `@RegisterProviders` annotation to define classes to be registered as providers in addition to providers registered via the `RestClientBuilder`
+
+== Automatic Provider Registration
+
+Implementations may provider any number of providers registered automatically, but t
+
+=== JSON-P Provider
+
+When an interface is registered that contains:
+- `@Produces("\*/json")` or
+- `@Consumes("\*/json")` or
+- a method that declares input or output of type `javax.json.JsonValue` or any subclass therein
+
+Then a JSON-P `MessageBodyReader` and `MessageBodyWriter` will be registered automatically by the implementation.  This is in alignment with the JAX-RS 2.0 specification.  The provider registered will have a priority of `Integer.MAX_VALUE`, allowing a user to register a custom provider to be used instead.
+
+=== Default Message Body Readers and Writers
+
+For the following types, and any media type, the runtime must support `MessageBodyReader`s and `MessageBodyWriter`s being automatically registered.
+
+- `byte[]`
+- `String`
+- `InputStream`
+- `Reader`
+- `File`
+
+==== Values supported with `text/plain`
+
+The following types are supported for automatic conversion, only when the media type is `text/plain`.
+
+- `Number`
+- `Character` and `char`
+- `Long` and `long`
+- `Integer` and `int`
+- `Double` and `double`
+- `Float` and `float`
+- `Boolean` and `boolean` (literal value of `true` and `false` only)
+
+=== Default ResponseExceptionMapper
 
 Each implementation will provide out of the box a `ResponseExceptionMapper` implementation that will map the response into a `WebApplicationException` whenever the response status code is >= 400.  It has a priority of `Integer.MAX_VALUE`.  It is meant to be used as a fall back whenever an error is encountered.  This mapper will be registered by default to all client interfaces.
 
 This behavior can be disabled by adding a configuration property `microprofile.rest.client.disable.default.mapper` with value `true` that will be resolved as a `boolean` via MicroProfile Config.
 
 It can also be disabled on a per client basis by using the same property when building the client, `RestClientBuilder.newBuilder().property("microprofile.rest.client.disable.default.mapper",true)`
-
-== Provider Declaration
-
-In addition to defining providers via the client definition, interfaces may use the `@RegisterProviders` annotation to define classes to be registered as providers in addition to providers registered via the `RestClientBuilder`

--- a/spec/src/main/asciidoc/providers.asciidoc
+++ b/spec/src/main/asciidoc/providers.asciidoc
@@ -92,7 +92,7 @@ In addition to defining providers via the client definition, interfaces may use 
 
 == Automatic Provider Registration
 
-Implementations may provide any number of providers registered automatically, but t
+Implementations may provide any number of providers registered automatically, but the following providers must be registered by the runtime.
 
 === JSON-P Provider
 

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -60,7 +60,12 @@
             <version>1.0</version>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <groupId>javax.json</groupId>
+            <artifactId>javax.json-api</artifactId>
+            <version>1.0</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeWithJsonPProviderTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeWithJsonPProviderTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.tck.interfaces.JsonPClient;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import javax.inject.Inject;
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+import javax.ws.rs.core.Response;
+import java.net.URL;
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.testng.Assert.assertEquals;
+
+public class InvokeWithJsonPProviderTest extends WiremockArquillianTest{
+
+    private static final String CDI = "cdi";
+    private static final String BUILT = "built";
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class)
+            .addClass(JsonPClient.class)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Inject
+    private JsonPClient cdiJsonPClient;
+
+    private JsonPClient builtJsonPClient;
+
+    @BeforeTest
+    public void setupClient() throws Exception{
+        builtJsonPClient = RestClientBuilder.newBuilder()
+            .baseUrl(new URL("http://localhost:"+ port))
+            .build(JsonPClient.class);
+        wireMockServer.resetAll();
+    }
+
+    @Test
+    public void testGetExecutesForBothClients() {
+        testGet(builtJsonPClient, BUILT);
+        testGet(cdiJsonPClient, CDI);
+    }
+
+    @Test
+    public void testGetSingleExecutesForBothClients() {
+        testGetSingle(builtJsonPClient, BUILT);
+        testGetSingle(cdiJsonPClient, CDI);
+    }
+
+    @Test
+    public void testPostExecutes() {
+        testPost(builtJsonPClient, BUILT);
+        testPost(cdiJsonPClient, CDI);
+    }
+
+    @Test
+    public void testPutExecutes() {
+        testPut(builtJsonPClient, BUILT);
+        testPut(cdiJsonPClient, CDI);
+    }
+
+    private void testGet(JsonPClient client, String clientType) {
+        wireMockServer.stubFor(get(urlEqualTo("/"))
+            .willReturn(aResponse()
+                .withBody("[{key: \"value\"}, {key: \"anotherValue\"}]")));
+        JsonArray jsonArray = client.get();
+        assertEquals(jsonArray.size(), 2, "Expected 2 values in the array for client "+clientType);
+        List<JsonObject> jsonObjects = jsonArray.getValuesAs(JsonObject.class);
+        JsonObject one = jsonObjects.get(0);
+        assertEquals(one.keySet().size(), 1, "There should only be one key in object 1 for client "+clientType);
+        assertEquals(one.getString("key"), "value", "The value of 'key' on object 1 should be 'value' in client "+clientType);
+
+        JsonObject two = jsonObjects.get(1);
+        assertEquals(two.keySet().size(), 1, "There should only be one key in object 2 for client "+clientType);
+        assertEquals(two.getString("key"), "anotherValue", "The value of 'key' on object 2 should be 'anotherValue' in client "+clientType);
+
+    }
+
+    private void testGetSingle(JsonPClient client, String clientType) {
+        wireMockServer.stubFor(get(urlEqualTo("/id"))
+            .willReturn(aResponse()
+                .withBody("{key: \"value\"}")));
+        JsonObject jsonObject = client.get("id");
+        assertEquals(jsonObject.keySet().size(), 1, "There should only be one key in object for client "+clientType);
+        assertEquals(jsonObject.getString("key"), "value", "The value of 'key' on object should be 'value' in client "+clientType);
+
+    }
+
+    private void testPost(JsonPClient client, String clientType) {
+        wireMockServer.stubFor(post(urlEqualTo("/")).willReturn(aResponse().withStatus(200)));
+
+        JsonObject jsonObject = Json.createObjectBuilder().add("someKey", "newValue").build();
+        Response response = client.post(jsonObject);
+        response.close();
+        assertEquals(response.getStatus(), 200, "Expected a 200 OK on client "+clientType);
+
+        wireMockServer.verify(1, postRequestedFor(urlEqualTo("/")).withRequestBody(equalTo("{someKey: \"newValue\"}")));
+    }
+
+    private void testPut(JsonPClient client, String clientType) {
+        wireMockServer.stubFor(put(urlEqualTo("/id")).willReturn(aResponse().withStatus(200).withBody("{someOtherKey: \"newValue\"}")));
+
+        JsonObject jsonObject = Json.createObjectBuilder().add("someKey", "newValue").build();
+        JsonObject response = client.update("id", jsonObject);
+        assertEquals(response.getString("someOtherKey"), "newValue",
+            "The value of 'someOtherKey' on response should be 'someOtherKey' in client "+clientType);
+
+        wireMockServer.verify(1, putRequestedFor(urlEqualTo("/id")).withRequestBody(equalTo("{someKey: \"newValue\"}")));
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/JsonPClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/JsonPClient.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Response;
+
+public interface JsonPClient {
+    @Path("/")
+    @GET
+    JsonArray get();
+
+    @Path("/{id}")
+    @GET
+    JsonObject get(@PathParam("id") String id);
+
+    @POST
+    @Path("/")
+    Response post(JsonObject object);
+
+    @PUT
+    @Path("/{id}")
+    JsonObject update(@PathParam("id") String id, JsonObject body);
+}


### PR DESCRIPTION
Specify how the JSON-P provider and other default providers are registered

TCK tests for the JSON-P side