### PR TITLE
Fixes #21 - a separate SPI for providing RestClientBuilder instances

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
@@ -22,13 +22,18 @@ import org.eclipse.microprofile.rest.client.spi.RestClientBuilderResolver;
 /**
  * This is the main entry point for creating a Type Safe Rest Client.
  * <p>
- * Invoking {@link newBuilder()} is intended to always create a new instance, not use a cached version.
+ * Invoking {@link newBuilder()} is intended to always create a new instance,
+ * not use a cached version.
+ * </p>
  * <p>
- * The <code>RestClientBuilder</code> is a {@link Configurable} class as defined by JAX-RS.  This allows a user to register providers,
- * implementation specific configuration.
+ * The <code>RestClientBuilder</code> is a {@link Configurable} class as defined
+ * by JAX-RS. This allows a user to register providers, implementation specific
+ * configuration.
+ * </p>
  * <p>
- * Implementations are expected
- * to implement this class and provide the instance via the mechanism in {@link RestClientBuilderResolver.instance()}.
+ * Implementations are expected to implement this class and provide the instance
+ * via the mechanism in {@link RestClientBuilderResolver#instance()}.
+ * </p>
  */
 public interface RestClientBuilder extends Configurable<RestClientBuilder> {
 
@@ -37,21 +42,29 @@ public interface RestClientBuilder extends Configurable<RestClientBuilder> {
     }
 
     /**
-     * Specifies the base URL to be used when making requests.  Assuming that the interface has a <code>@Path("/api")</code> at the interface level
-     * and a <code>url</code> is given with <code>http://my-service:8080/service</code> then all REST calls will be invoked with a <code>url</code> of
-     * <code>http://my-service:8080/service/api</code> in addition to any <code>@Path</code> annotations included on the method.
+     * Specifies the base URL to be used when making requests. Assuming that the
+     * interface has a <code>@Path("/api")</code> at the interface level and a
+     * <code>url</code> is given with
+     * <code>http://my-service:8080/service</code> then all REST calls will be
+     * invoked with a <code>url</code> of
+     * <code>http://my-service:8080/service/api</code> in addition to any
+     * <code>@Path</code> annotations included on the method.
+     *
      * @param url the base Url for the service.
      * @return the current builder with the baseUrl set
      */
     public abstract RestClientBuilder baseUrl(URL url);
 
     /**
-     * Based on the configured RestClientBuilder, creates a new instance of the given REST interface to invoke API calls against.
+     * Based on the configured RestClientBuilder, creates a new instance of the
+     * given REST interface to invoke API calls against.
+     *
      * @param clazz the interface that defines REST API methods for use
      * @param <T> the type of the interface
      * @return a new instance of an implementation of this REST interface that
-     * @throws IllegalStateException if not all pre-requisites are satisfied for the builder, this exception may get thrown.  For instance, if a URL
-     *  has not been set.
+     * @throws IllegalStateException if not all pre-requisites are satisfied for
+     * the builder, this exception may get thrown. For instance, if a URL has
+     * not been set.
      */
     public abstract <T> T build(Class<T> clazz) throws IllegalStateException;
 

--- a/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
@@ -9,55 +9,37 @@
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either excodess or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package org.eclipse.microprofile.rest.client;
 
-import javax.annotation.Priority;
 import javax.ws.rs.core.Configurable;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.ServiceLoader;
-import java.util.function.ToIntFunction;
+import org.eclipse.microprofile.rest.client.spi.RestClientBuilderResolver;
 
 /**
+ * This is the main entry point for creating a Type Safe Rest Client.
  * <p>
- * This is the main entry point for creating a Type Safe Rest Client.  Implementations are expected
- * to implement this class and register a service provider via {@link ServiceLoader} that works within their implementation.
+ * Invoking {@link newBuilder()} is intended to always create a new instance, not use a cached version.
  * <p>
- * Invoking <pre>RestClientBuilder.newBuilder()</pre> is intended to always create a new instance, not use a cached version.
- * <p>
- * If multiple implementations of RestClientBuilder are discovered, the one with the highest value of the {@link Priority} annotation is used
- * <p>
- * The {@link ServiceLoader} will first search via the current Thread's Context ClassLoader, then {@link RestClientBuilder}'s {@link ClassLoader}
- * <p>
- * The <pre>RestClientBuilder</pre> is a {@link Configurable} class as defined by JAX-RS.  This allows a user to register providers,
+ * The <code>RestClientBuilder</code> is a {@link Configurable} class as defined by JAX-RS.  This allows a user to register providers,
  * implementation specific configuration.
+ * <p>
+ * Implementations are expected
+ * to implement this class and provide the instance via the mechanism in {@link RestClientBuilderResolver.instance()}.
  */
 public interface RestClientBuilder extends Configurable<RestClientBuilder> {
 
     public static RestClientBuilder newBuilder() {
-        ServiceLoader<RestClientBuilder> loader = ServiceLoader.load(RestClientBuilder.class);
-        List<RestClientBuilder> clientBuilders = new ArrayList<>();
-        loader.forEach(clientBuilders::add);
-        loader = ServiceLoader.load(RestClientBuilder.class, RestClientBuilder.class.getClassLoader());
-        loader.forEach(clientBuilders::add);
-
-        if (clientBuilders.size() == 0) {
-            throw new RuntimeException("No implementation of '" + RestClientBuilder.class.getSimpleName() + "' found");
-        }
-        clientBuilders.sort(Comparator.comparingInt(PrivateRestClientBuilder.priorityComparator()).reversed());
-        return clientBuilders.get(0);
+        return RestClientBuilderResolver.instance().newBuilder();
     }
 
     /**
-     * Specifies the base URL to be used when making requests.  Assuming that the interface has a <pre>@Path("/api")</pre> at the interface level
-     * and a <pre>url</pre> is given with <pre>http://my-service:8080/service</pre> then all REST calls will be invoked with a <pre>url</pre> of
-     * <pre>http://my-service:8080/service/api</pre> in addition to any <pre>@Path</pre> annotations included on the method.
+     * Specifies the base URL to be used when making requests.  Assuming that the interface has a <code>@Path("/api")</code> at the interface level
+     * and a <code>url</code> is given with <code>http://my-service:8080/service</code> then all REST calls will be invoked with a <code>url</code> of
+     * <code>http://my-service:8080/service/api</code> in addition to any <code>@Path</code> annotations included on the method.
      * @param url the base Url for the service.
      * @return the current builder with the baseUrl set
      */
@@ -68,28 +50,9 @@ public interface RestClientBuilder extends Configurable<RestClientBuilder> {
      * @param clazz the interface that defines REST API methods for use
      * @param <T> the type of the interface
      * @return a new instance of an implementation of this REST interface that
-     * @throws IllegalStateException if not all pre-requisites are satisfied for the builder, this exception may get thrown.  For instance, if a URL
+     * @throws IllegalStateException if not all code-requisites are satisfied for the builder, this exception may get thrown.  For instance, if a URL
      *  has not been set.
      */
     public abstract <T> T build(Class<T> clazz) throws IllegalStateException;
 
-}
-
-class PrivateRestClientBuilder {
-    
-    private PrivateRestClientBuilder() {
-        // shouldn't be instantiated
-    }
-
-    static ToIntFunction<Object> priorityComparator() {
-        return value -> {
-            Priority priority = value.getClass().getAnnotation(Priority.class);
-            if (priority == null) {
-                return 1;
-            }
-            else {
-                return priority.value();
-            }
-        };
-    }
 }

--- a/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
@@ -9,7 +9,7 @@
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either excodess or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
@@ -50,7 +50,7 @@ public interface RestClientBuilder extends Configurable<RestClientBuilder> {
      * @param clazz the interface that defines REST API methods for use
      * @param <T> the type of the interface
      * @return a new instance of an implementation of this REST interface that
-     * @throws IllegalStateException if not all code-requisites are satisfied for the builder, this exception may get thrown.  For instance, if a URL
+     * @throws IllegalStateException if not all pre-requisites are satisfied for the builder, this exception may get thrown.  For instance, if a URL
      *  has not been set.
      */
     public abstract <T> T build(Class<T> clazz) throws IllegalStateException;

--- a/api/src/main/java/org/eclipse/microprofile/rest/client/spi/RestClientBuilderResolver.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/spi/RestClientBuilderResolver.java
@@ -95,7 +95,8 @@ public class RestClientBuilderResolver {
         Priority priority = value.getClass().getAnnotation(Priority.class);
         if (priority == null) {
             return 1;
-        } else {
+        }
+        else {
             return priority.value();
         }
     }
@@ -156,7 +157,8 @@ public class RestClientBuilderResolver {
                             "Multiple RestClientBuilderResolver implementations found: "
                             + spi.getClass().getName() + " and "
                             + resolver.getClass().getName());
-                } else {
+                }
+                else {
                     resolver = spi;
                 }
             }

--- a/api/src/main/java/org/eclipse/microprofile/rest/client/spi/RestClientBuilderResolver.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/spi/RestClientBuilderResolver.java
@@ -1,0 +1,177 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.rest.client.spi;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.ServiceLoader;
+import javax.annotation.Priority;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+
+/**
+ * This class is not intended to be used by end-users but for portable container
+ * integration purpose only.
+ * <p>
+ * Resolver for a {@link RestClientBuilder} implementation. The implementation
+ * registers itself via the {@link java.util.ServiceLoader} mechanism or via
+ * {@link setInstance(RestClientBuilderResolver resolver)}.
+ * <p>
+ * This class provides a default implementation which uses the service loader
+ * pattern to look for all implementations of <code>RestClientBuilder</code> and
+ * creates a new builder with the highest priority specified by the
+ * {@link Priority} annotation.
+ * <p>
+ * Implementations may override the {@link newBuilder()} method to create custom
+ * <code>RestClientBuilder</code> implementations.
+ *
+ * @author Ondrej Mihalyi
+ */
+public class RestClientBuilderResolver {
+
+    private static volatile RestClientBuilderResolver instance = null;
+
+    protected RestClientBuilderResolver() {
+    }
+
+    /**
+     * Creates a new RestClientBuilder instance.
+     * <p>
+     * Implementations are expected to override the {@link newBuilder()} method
+     * to create custom RestClientBuilder implementations.
+     * <p>
+     * The default implementation uses the service loader pattern to look for
+     * all implementations of RestClientBuilder and creates a new builder with
+     * the highest priority specified with the {@link Priority} annotation. The
+     * priority is 1 it the annotations isn't present.
+     * <p>
+     * The {@link ServiceLoader} will first search via the current Thread's
+     * Context ClassLoader, then {@link RestClientBuilder}'s {@link ClassLoader}
+     *
+     * @return new RestClientBuilder instance
+     */
+    public RestClientBuilder newBuilder() {
+        ServiceLoader<RestClientBuilder> loader = ServiceLoader.load(RestClientBuilder.class);
+        List<RestClientBuilder> clientBuilders = new ArrayList<>();
+        loader.forEach(clientBuilders::add);
+        loader = ServiceLoader.load(RestClientBuilder.class, RestClientBuilder.class.getClassLoader());
+        loader.forEach(clientBuilders::add);
+
+        if (clientBuilders.isEmpty()) {
+            throw new RuntimeException("No implementation of '" + RestClientBuilder.class.getSimpleName() + "' found");
+        }
+        clientBuilders.sort(Comparator.comparingInt(this::getBuilderPriority)
+                .reversed());
+        return clientBuilders.get(0);
+    }
+
+    /**
+     * Computes priority for a builder.
+     *
+     * @param value builder instance which can be annotated with
+     * {@link Priority}
+     * @return the priority of the builder
+     */
+    protected int getBuilderPriority(RestClientBuilder value) {
+        Priority priority = value.getClass().getAnnotation(Priority.class);
+        if (priority == null) {
+            return 1;
+        } else {
+            return priority.value();
+        }
+    }
+
+    /**
+     * Gets or creates a RestClientBuilderResolver instance. Only used
+     * internally from within {@link RestClientBuilder}
+     *
+     * @return an instance of RestClientBuilderResolver
+     */
+    // method copied and adapted from ConfigProviderResolver in microprofile-config
+    public static RestClientBuilderResolver instance() {
+        if (instance == null) {
+            synchronized (RestClientBuilderResolver.class) {
+                if (instance != null) {
+                    return instance;
+                }
+
+                ClassLoader cl = AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
+                    @Override
+                    public ClassLoader run() {
+                        return Thread.currentThread().getContextClassLoader();
+                    }
+                });
+                if (cl == null) {
+                    cl = RestClientBuilderResolver.class.getClassLoader();
+                }
+
+                RestClientBuilderResolver newInstance = loadSpi(cl);
+
+                if (newInstance == null) {
+                    throw new IllegalStateException(
+                            "No RestClientBuilderResolver implementation found!");
+                }
+
+                instance = newInstance;
+            }
+        }
+
+        return instance;
+    }
+
+    // method copied and adapted from ConfigProviderResolver in microprofile-config
+    private static RestClientBuilderResolver loadSpi(ClassLoader cl) {
+        if (cl == null) {
+            return null;
+        }
+
+        // start from the root CL and go back down to the TCCL
+        RestClientBuilderResolver resolver = loadSpi(cl.getParent());
+
+        if (resolver == null) {
+            ServiceLoader<RestClientBuilderResolver> sl = ServiceLoader.load(
+                    RestClientBuilderResolver.class, cl);
+            for (RestClientBuilderResolver spi : sl) {
+                if (resolver != null) {
+                    throw new IllegalStateException(
+                            "Multiple RestClientBuilderResolver implementations found: "
+                            + spi.getClass().getName() + " and "
+                            + resolver.getClass().getName());
+                } else {
+                    resolver = spi;
+                }
+            }
+        }
+        return resolver;
+    }
+
+    /**
+     * Set the instance. It can be as an alternative to service loader pattern,
+     * e.g. in OSGi environment
+     *
+     * @param resolver instance.
+     */
+    public static void setInstance(RestClientBuilderResolver resolver) {
+        instance = resolver;
+    }
+
+}


### PR DESCRIPTION
I created a separate class `RestClientBuilderResolver` to provide instances of `RestClientBuilder`. I think `RestClientBuilderResolver` is a better name than `RestClientBuilderPovider` agreed in #21 because in the config spec, `ConfigProvider` is a part of API and `ConfigProviderResolver` is a part of SPI. The new `RestClientBuilderProvider` does a similar job to `ConfigProviderResolver. There's nothing like ConfigProvider in the REST client API because there's no single client API, only builder.

I also left the default behavior of loading `RestClientBuilder` instances via service loader but moved it to the new class to a method which can be overridden by the implementaions. The code is very simple and might be enough for some implementations.