### PR TITLE
Fixes a large amount of TCK debugging issues faced when completing an…

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
@@ -37,7 +37,7 @@ import org.eclipse.microprofile.rest.client.spi.RestClientBuilderResolver;
  */
 public interface RestClientBuilder extends Configurable<RestClientBuilder> {
 
-    public static RestClientBuilder newBuilder() {
+    static RestClientBuilder newBuilder() {
         return RestClientBuilderResolver.instance().newBuilder();
     }
 
@@ -53,7 +53,7 @@ public interface RestClientBuilder extends Configurable<RestClientBuilder> {
      * @param url the base Url for the service.
      * @return the current builder with the baseUrl set
      */
-    public abstract RestClientBuilder baseUrl(URL url);
+    RestClientBuilder baseUrl(URL url);
 
     /**
      * Based on the configured RestClientBuilder, creates a new instance of the
@@ -66,6 +66,6 @@ public interface RestClientBuilder extends Configurable<RestClientBuilder> {
      * the builder, this exception may get thrown. For instance, if a URL has
      * not been set.
      */
-    public abstract <T> T build(Class<T> clazz) throws IllegalStateException;
+    <T> T build(Class<T> clazz) throws IllegalStateException;
 
 }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/CallMultipleMappersTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/CallMultipleMappersTest.java
@@ -25,13 +25,11 @@ import org.eclipse.microprofile.rest.client.tck.providers.TestResponseExceptionM
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import javax.ws.rs.WebApplicationException;
-import java.net.URL;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -45,22 +43,20 @@ public class CallMultipleMappersTest extends WiremockArquillianTest {
     public static Archive<?> createDeployment() {
         return ShrinkWrap.create(WebArchive.class, CallMultipleMappersTest.class.getSimpleName()+".war")
             .addClasses(TestResponseExceptionMapper.class, TestResponseExceptionMapperHandles.class)
-            .addClasses(SimpleGetApi.class)
-            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+            .addClasses(SimpleGetApi.class);
     }
 
     @BeforeTest
     public void resetHandlers() {
         TestResponseExceptionMapper.reset();
         TestResponseExceptionMapperHandles.reset();
-        wireMockServer
-            .stubFor(get(urlEqualTo("/")).willReturn(aResponse().withBody("body is ignored in this test")));
+        getWireMockServer().stubFor(get(urlEqualTo("/")).willReturn(aResponse().withBody("body is ignored in this test")));
     }
 
     @Test
     public void testCallsTwoProvidersWithTwoRegisteredProvider() throws Exception {
         SimpleGetApi simpleGetApi = RestClientBuilder.newBuilder()
-            .baseUrl(new URL("http://localhost:"+ port))
+            .baseUrl(getServerURL())
             .register(TestResponseExceptionMapper.class)
             .register(TestResponseExceptionMapperHandles.class)
             .build(SimpleGetApi.class);

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/DefaultExceptionMapperTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/DefaultExceptionMapperTest.java
@@ -24,14 +24,12 @@ import org.eclipse.microprofile.rest.client.tck.providers.LowerPriorityTestRespo
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
-import java.net.URL;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -48,21 +46,19 @@ public class DefaultExceptionMapperTest extends WiremockArquillianTest {
     @Deployment
     public static Archive<?> createDeployment() {
         return ShrinkWrap.create(WebArchive.class, DefaultExceptionMapperTest.class.getSimpleName()+".war")
-            .addClasses(SimpleGetApi.class, LowerPriorityTestResponseExceptionMapper.class)
-            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+            .addClasses(SimpleGetApi.class, LowerPriorityTestResponseExceptionMapper.class);
     }
 
     @BeforeTest
     public void resetHandlers() {
         LowerPriorityTestResponseExceptionMapper.reset();
-        wireMockServer
-            .stubFor(get(urlEqualTo("/")).willReturn(aResponse().withStatus(STATUS).withBody(BODY)));
+        getWireMockServer().stubFor(get(urlEqualTo("/")).willReturn(aResponse().withStatus(STATUS).withBody(BODY)));
     }
 
     @Test
     public void testPropagationOfResponseDetailsFromDefaultMapper() throws Exception {
         SimpleGetApi simpleGetApi = RestClientBuilder.newBuilder()
-            .baseUrl(new URL("http://localhost:"+ port))
+            .baseUrl(getServerURL())
             .build(SimpleGetApi.class);
 
         try {
@@ -84,7 +80,7 @@ public class DefaultExceptionMapperTest extends WiremockArquillianTest {
     @Test
     public void testLowerPriorityMapperTakesPrecedenceFromDefault() throws Exception {
         SimpleGetApi simpleGetApi = RestClientBuilder.newBuilder()
-            .baseUrl(new URL("http://localhost:"+ port))
+            .baseUrl(getServerURL())
             .register(LowerPriorityTestResponseExceptionMapper.class)
             .build(SimpleGetApi.class);
 

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ExceptionMapperTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ExceptionMapperTest.java
@@ -25,13 +25,11 @@ import org.eclipse.microprofile.rest.client.tck.providers.TestResponseExceptionM
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import javax.ws.rs.WebApplicationException;
-import java.net.URL;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -46,22 +44,21 @@ public class ExceptionMapperTest extends WiremockArquillianTest{
     public static Archive<?> createDeployment() {
         return ShrinkWrap.create(WebArchive.class, ExceptionMapperTest.class.getSimpleName()+".war")
             .addClasses(TestResponseExceptionMapper.class, TestResponseExceptionMapperOverridePriority.class)
-            .addClasses(SimpleGetApi.class)
-            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+            .addClasses(SimpleGetApi.class);
     }
 
     @BeforeTest
     public void resetHandlers() {
         TestResponseExceptionMapper.reset();
         TestResponseExceptionMapperOverridePriority.reset();
-        wireMockServer
+        getWireMockServer()
             .stubFor(get(urlEqualTo("/")).willReturn(aResponse().withBody("body is ignored in this test")));
     }
 
     @Test
     public void testWithOneRegisteredProvider() throws Exception {
         SimpleGetApi simpleGetApi = RestClientBuilder.newBuilder()
-            .baseUrl(new URL("http://localhost:"+ port))
+            .baseUrl(getServerURL())
             .register(TestResponseExceptionMapper.class)
             .build(SimpleGetApi.class);
 
@@ -82,7 +79,7 @@ public class ExceptionMapperTest extends WiremockArquillianTest{
     @Test
     public void testWithTwoRegisteredProviders() throws Exception{
         SimpleGetApi simpleGetApi = RestClientBuilder.newBuilder()
-            .baseUrl(new URL("http://localhost:"+ port))
+            .baseUrl(getServerURL())
             .register(TestResponseExceptionMapper.class)
             .register(TestResponseExceptionMapperOverridePriority.class)
             .build(SimpleGetApi.class);

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeSimpleGetOperationTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeSimpleGetOperationTest.java
@@ -20,12 +20,10 @@ import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
 import javax.ws.rs.core.Response;
-import java.net.URL;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -37,19 +35,18 @@ public class InvokeSimpleGetOperationTest extends WiremockArquillianTest{
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
-            .addClass(SimpleGetApi.class)
-            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+            .addClass(SimpleGetApi.class);
     }
 
     @Test
-    public void testInvokesOperation() throws Exception{
+    public void testGetExecutionWithBuiltClient() throws Exception{
         String expectedBody = "Hello, MicroProfile!";
-        wireMockServer.stubFor(get(urlEqualTo("/"))
+        getWireMockServer().stubFor(get(urlEqualTo("/"))
             .willReturn(aResponse()
                 .withBody(expectedBody)));
 
         SimpleGetApi simpleGetApi = RestClientBuilder.newBuilder()
-            .baseUrl(new URL("http://localhost:"+ port))
+            .baseUrl(getServerURL())
             .build(SimpleGetApi.class);
 
         Response response = simpleGetApi.executeGet();
@@ -60,6 +57,6 @@ public class InvokeSimpleGetOperationTest extends WiremockArquillianTest{
 
         assertEquals(body, expectedBody);
 
-        wireMockServer.verify(1, getRequestedFor(urlEqualTo("/")));
+        getWireMockServer().verify(1, getRequestedFor(urlEqualTo("/")));
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeWithBuiltProvidersTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeWithBuiltProvidersTest.java
@@ -29,13 +29,11 @@ import org.eclipse.microprofile.rest.client.tck.providers.TestReaderInterceptor;
 import org.eclipse.microprofile.rest.client.tck.providers.TestWriterInterceptor;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
 import javax.ws.rs.core.Response;
 import java.net.MalformedURLException;
-import java.net.URL;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
@@ -51,19 +49,16 @@ public class InvokeWithBuiltProvidersTest extends WiremockArquillianTest {
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
             .addClass(InterfaceWithoutProvidersDefined.class)
-            .addPackage(TestClientResponseFilter.class.getPackage())
-            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+            .addPackage(TestClientResponseFilter.class.getPackage());
     }
 
     @Test
-    public void testInvokesPostOperation() throws Exception{
+    public void testInvokesPostOperationWithRegisteredProviders() throws Exception{
         String inputBody = "input body will be removed";
         String outputBody = "output body will be removed";
         String expectedReceivedBody = "this is the replaced writer "+inputBody;
         String expectedResponseBody = TestMessageBodyReader.REPLACED_BODY;
-        wireMockServer.stubFor(post(urlEqualTo("/"))
-            .willReturn(aResponse()
-                .withBody(outputBody)));
+        getWireMockServer().stubFor(post(urlEqualTo("/")).willReturn(aResponse().withBody(outputBody)));
 
         InterfaceWithoutProvidersDefined api = createClient();
 
@@ -75,7 +70,7 @@ public class InvokeWithBuiltProvidersTest extends WiremockArquillianTest {
 
         assertEquals(body, expectedResponseBody);
 
-        wireMockServer.verify(1, postRequestedFor(urlEqualTo("/")).withRequestBody(equalTo(expectedReceivedBody)));
+        getWireMockServer().verify(1, postRequestedFor(urlEqualTo("/")).withRequestBody(equalTo(expectedReceivedBody)));
 
         assertEquals(TestClientResponseFilter.getAndResetValue(),1);
         assertEquals(TestClientRequestFilter.getAndResetValue(),1);
@@ -84,14 +79,14 @@ public class InvokeWithBuiltProvidersTest extends WiremockArquillianTest {
     }
 
     @Test
-    public void testInvokesPutOperation() throws Exception {
+    public void testInvokesPutOperationWithRegisteredProviders() throws Exception {
         String inputBody = "input body will be removed";
         String outputBody = "output body will be removed";
         String expectedReceivedBody = "this is the replaced writer "+inputBody;
         String expectedResponseBody = TestMessageBodyReader.REPLACED_BODY;
         String id = "id";
         String expectedId = "toStringid";
-        wireMockServer.stubFor(put(urlEqualTo("/"+expectedId))
+        getWireMockServer().stubFor(put(urlEqualTo("/"+expectedId))
             .willReturn(aResponse()
                 .withBody(outputBody)));
 
@@ -105,7 +100,7 @@ public class InvokeWithBuiltProvidersTest extends WiremockArquillianTest {
 
         assertEquals(body, expectedResponseBody);
 
-        wireMockServer.verify(1, putRequestedFor(urlEqualTo("/"+expectedId)).withRequestBody(equalTo(expectedReceivedBody)));
+        getWireMockServer().verify(1, putRequestedFor(urlEqualTo("/"+expectedId)).withRequestBody(equalTo(expectedReceivedBody)));
 
         assertEquals(TestClientResponseFilter.getAndResetValue(),1);
         assertEquals(TestClientRequestFilter.getAndResetValue(),1);
@@ -122,7 +117,7 @@ public class InvokeWithBuiltProvidersTest extends WiremockArquillianTest {
             .register(TestParamConverterProvider.class)
             .register(TestReaderInterceptor.class)
             .register(TestWriterInterceptor.class)
-            .baseUrl(new URL("http://localhost:"+ port))
+            .baseUrl(getServerURL())
             .build(InterfaceWithoutProvidersDefined.class);
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeWithRegisteredProvidersTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeWithRegisteredProvidersTest.java
@@ -27,12 +27,10 @@ import org.eclipse.microprofile.rest.client.tck.providers.TestReaderInterceptor;
 import org.eclipse.microprofile.rest.client.tck.providers.TestWriterInterceptor;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
 import javax.ws.rs.core.Response;
-import java.net.URL;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
@@ -48,22 +46,21 @@ public class InvokeWithRegisteredProvidersTest extends WiremockArquillianTest {
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
             .addClass(InterfaceWithProvidersDefined.class)
-            .addPackage(TestClientResponseFilter.class.getPackage())
-            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+            .addPackage(TestClientResponseFilter.class.getPackage());
     }
 
     @Test
-    public void testInvokesPostOperation() throws Exception{
+    public void testInvokesPostOperationWithAnnotatedProviders() throws Exception{
         String inputBody = "input body will be removed";
         String outputBody = "output body will be removed";
         String expectedReceivedBody = "this is the replaced writer "+inputBody;
         String expectedResponseBody = TestMessageBodyReader.REPLACED_BODY;
-        wireMockServer.stubFor(post(urlEqualTo("/"))
+        getWireMockServer().stubFor(post(urlEqualTo("/"))
             .willReturn(aResponse()
                 .withBody(outputBody)));
 
         InterfaceWithProvidersDefined api = RestClientBuilder.newBuilder()
-            .baseUrl(new URL("http://localhost:"+ port))
+            .baseUrl(getServerURL())
             .build(InterfaceWithProvidersDefined.class);
 
         Response response = api.executePost(inputBody);
@@ -74,7 +71,7 @@ public class InvokeWithRegisteredProvidersTest extends WiremockArquillianTest {
 
         assertEquals(body, expectedResponseBody);
 
-        wireMockServer.verify(1, postRequestedFor(urlEqualTo("/")).withRequestBody(equalTo(expectedReceivedBody)));
+        getWireMockServer().verify(1, postRequestedFor(urlEqualTo("/")).withRequestBody(equalTo(expectedReceivedBody)));
 
         assertEquals(TestClientResponseFilter.getAndResetValue(),1);
         assertEquals(TestClientRequestFilter.getAndResetValue(),1);
@@ -83,19 +80,19 @@ public class InvokeWithRegisteredProvidersTest extends WiremockArquillianTest {
     }
 
     @Test
-    public void testInvokesPutOperation() throws Exception {
+    public void testInvokesPutOperationWithAnnotatedProviders() throws Exception {
         String inputBody = "input body will be removed";
         String outputBody = "output body will be removed";
         String expectedReceivedBody = "this is the replaced writer "+inputBody;
         String expectedResponseBody = TestMessageBodyReader.REPLACED_BODY;
         String id = "id";
         String expectedId = "toStringid";
-        wireMockServer.stubFor(put(urlEqualTo("/"+expectedId))
+        getWireMockServer().stubFor(put(urlEqualTo("/"+expectedId))
             .willReturn(aResponse()
                 .withBody(outputBody)));
 
         InterfaceWithProvidersDefined api = RestClientBuilder.newBuilder()
-            .baseUrl(new URL("http://localhost:"+ port))
+            .baseUrl(getServerURL())
             .build(InterfaceWithProvidersDefined.class);
 
         Response response = api.executePut(id, inputBody);
@@ -106,7 +103,7 @@ public class InvokeWithRegisteredProvidersTest extends WiremockArquillianTest {
 
         assertEquals(body, expectedResponseBody);
 
-        wireMockServer.verify(1, putRequestedFor(urlEqualTo("/"+expectedId)).withRequestBody(equalTo(expectedReceivedBody)));
+        getWireMockServer().verify(1, putRequestedFor(urlEqualTo("/"+expectedId)).withRequestBody(equalTo(expectedReceivedBody)));
 
         assertEquals(TestClientResponseFilter.getAndResetValue(),1);
         assertEquals(TestClientRequestFilter.getAndResetValue(),1);

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/WiremockArquillianTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/WiremockArquillianTest.java
@@ -20,17 +20,22 @@ package org.eclipse.microprofile.rest.client.tck;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import org.jboss.arquillian.testng.Arquillian;
-import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
+
+import java.net.MalformedURLException;
+import java.net.URL;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 
-public abstract class WiremockArquillianTest extends Arquillian{
-    protected static int port;
-    protected WireMockServer wireMockServer;
+public abstract class WiremockArquillianTest extends Arquillian {
+    private static Integer port;
+    private static WireMockServer wireMockServer;
 
-    protected static int getPort() {
+    private static Integer getPort() {
+        if(port == null) {
+            setupPort();
+        }
         return port;
     }
 
@@ -38,19 +43,32 @@ public abstract class WiremockArquillianTest extends Arquillian{
         return wireMockServer;
     }
 
-    @BeforeClass
-    public static void setupPort() {
-        port = Integer.parseInt(System.getProperty("wiremock.server.port","8765"));
+    protected static URL getServerURL() {
+        try {
+            return new URL(getStringURL());
+        }
+        catch (MalformedURLException e) {
+            throw new RuntimeException("Malformed URL not expected", e);
+        }
     }
 
-    @BeforeMethod
-    public void startMockServer() {
-        wireMockServer = new WireMockServer(options().port(port));
+    protected static String getStringURL() {
+        return "http://localhost:" + getPort();
+    }
+
+    @BeforeClass
+    public static void setupServer() {
+        setupPort();
+        wireMockServer = new WireMockServer(options().port(getPort()));
         wireMockServer.start();
     }
 
-    @AfterMethod
-    public void stopServer() {
+    private static void setupPort() {
+        port = Integer.parseInt(System.getProperty("wiremock.server.port", "8765"));
+    }
+
+    @AfterClass
+    public static void stopServer() {
         wireMockServer.stop();
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/CDIInvokeSimpleGetOperationTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/CDIInvokeSimpleGetOperationTest.java
@@ -25,6 +25,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
@@ -53,15 +54,16 @@ public class CDIInvokeSimpleGetOperationTest extends WiremockArquillianTest{
     @Deployment
     public static WebArchive createDeployment() {
         String propertyName = SimpleGetApi.class.getName()+"/mp-rest/url";
-        String value = "http://localhost:"+ getPort();
-        return ShrinkWrap.create(WebArchive.class)
-            .addClass(SimpleGetApi.class)
+        String value = getStringURL();
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class).addClass(SimpleGetApi.class)
             .addAsManifestResource(new StringAsset(propertyName+"="+value), "microprofile-config.properties")
             .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        return ShrinkWrap.create(WebArchive.class)
+            .addAsLibrary(jar)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
-
     @Test
-    public void testInvokesOperation() throws Exception{
+    public void testInvokesGetOperationWithCDIBean() throws Exception{
         String expectedBody = "Hello, MicroProfile!";
         getWireMockServer().stubFor(get(urlEqualTo("/"))
             .willReturn(aResponse()

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/CDIInvokeWithRegisteredProvidersTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/CDIInvokeWithRegisteredProvidersTest.java
@@ -30,6 +30,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
@@ -56,11 +57,14 @@ public class CDIInvokeWithRegisteredProvidersTest extends WiremockArquillianTest
     @Deployment
     public static WebArchive createDeployment() {
         String propertyName = InterfaceWithProvidersDefined.class.getName()+"/mp-rest/url";
-        String value = "http://localhost:"+ getPort();
-        return ShrinkWrap.create(WebArchive.class)
+        String value = getStringURL();
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class)
             .addClass(InterfaceWithProvidersDefined.class)
             .addPackage(TestClientResponseFilter.class.getPackage())
             .addAsManifestResource(new StringAsset(propertyName+"="+value), "microprofile-config.properties")
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        return ShrinkWrap.create(WebArchive.class)
+            .addAsLibrary(jar)
             .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasAppScopeTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasAppScopeTest.java
@@ -18,6 +18,7 @@
 
 package org.eclipse.microprofile.rest.client.tck.cditests;
 
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -25,6 +26,7 @@ import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
@@ -51,9 +53,12 @@ public class HasAppScopeTest extends Arquillian {
         String url = SimpleGetApi.class.getName() + "/mp-rest/url=http://localhost:8080";
         String url2 = MyAppScopedApi.class.getName() + "/mp-rest/url=http://localhost:8080";
         String scope = SimpleGetApi.class.getName() + "/mp-rest/scope=" + ApplicationScoped.class.getName();
-        return ShrinkWrap.create(WebArchive.class)
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class)
             .addClasses(SimpleGetApi.class, MyAppScopedApi.class)
             .addAsManifestResource(new StringAsset(url + "\n" + scope + "\n"+ url2), "microprofile-config.properties")
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        return ShrinkWrap.create(WebArchive.class)
+            .addAsLibrary(jar)
             .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
@@ -73,6 +78,7 @@ public class HasAppScopeTest extends Arquillian {
 
     @ApplicationScoped
     @Path("/")
+    @RegisterRestClient
     public interface MyAppScopedApi {
         @GET
         public Response get();

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasConversationScopeTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasConversationScopeTest.java
@@ -18,6 +18,7 @@
 
 package org.eclipse.microprofile.rest.client.tck.cditests;
 
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -25,6 +26,7 @@ import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
@@ -51,9 +53,12 @@ public class HasConversationScopeTest extends Arquillian {
         String url = SimpleGetApi.class.getName() + "/mp-rest/url=http://localhost:8080";
         String url2 = MyConversationScopedApi.class.getName() + "/mp-rest/url=http://localhost:8080";
         String scope = SimpleGetApi.class.getName() + "/mp-rest/scope=" + ConversationScoped.class.getName();
-        return ShrinkWrap.create(WebArchive.class)
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class)
             .addClasses(SimpleGetApi.class, MyConversationScopedApi.class)
             .addAsManifestResource(new StringAsset(url + "\n" + scope + "\n" + url2), "microprofile-config.properties")
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        return ShrinkWrap.create(WebArchive.class)
+            .addAsLibrary(jar)
             .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
@@ -73,6 +78,7 @@ public class HasConversationScopeTest extends Arquillian {
 
     @Path("/")
     @ConversationScoped
+    @RegisterRestClient
     public interface MyConversationScopedApi {
         @GET
         public Response get();

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasRequestScopeTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasRequestScopeTest.java
@@ -18,6 +18,7 @@
 
 package org.eclipse.microprofile.rest.client.tck.cditests;
 
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -25,6 +26,7 @@ import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
@@ -33,6 +35,7 @@ import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
+import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 import java.util.Set;
 
@@ -50,9 +53,12 @@ public class HasRequestScopeTest extends Arquillian {
         String url = SimpleGetApi.class.getName() + "/mp-rest/url=http://localhost:8080";
         String url2 = MyRequestScopedApi.class.getName() + "/mp-rest/url=http://localhost:8080";
         String scope = SimpleGetApi.class.getName() + "/mp-rest/scope=" + RequestScoped.class.getName();
-        return ShrinkWrap.create(WebArchive.class)
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class)
             .addClasses(SimpleGetApi.class, MyRequestScopedApi.class)
             .addAsManifestResource(new StringAsset(url + "\n" + scope + "\n" + url2), "microprofile-config.properties")
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        return ShrinkWrap.create(WebArchive.class)
+            .addAsLibrary(jar)
             .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
@@ -71,6 +77,8 @@ public class HasRequestScopeTest extends Arquillian {
     }
 
     @RequestScoped
+    @RegisterRestClient
+    @Path("/")
     public interface MyRequestScopedApi {
         @GET
         public Response get();

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasSessionScopeTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasSessionScopeTest.java
@@ -18,6 +18,7 @@
 
 package org.eclipse.microprofile.rest.client.tck.cditests;
 
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -25,6 +26,7 @@ import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
@@ -48,11 +50,13 @@ public class HasSessionScopeTest extends Arquillian{
     @Deployment
     public static WebArchive createDeployment() {
         String url = SimpleGetApi.class.getName()+"/mp-rest/url=http://localhost:8080";
-        String url2 = MySessionScopedApi.class.getName()+"/mp-rest/url=http://localhost:8080";
         String scope = SimpleGetApi.class.getName()+"/mp-rest/scope="+ SessionScoped.class.getName();
-        return ShrinkWrap.create(WebArchive.class)
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class)
             .addClasses(SimpleGetApi.class, MySessionScopedApi.class)
             .addAsManifestResource(new StringAsset(url+"\n"+scope), "microprofile-config.properties")
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        return ShrinkWrap.create(WebArchive.class)
+            .addAsLibrary(jar)
             .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
     @Test
@@ -71,6 +75,7 @@ public class HasSessionScopeTest extends Arquillian{
 
     @SessionScoped
     @Path("/")
+    @RegisterRestClient
     public interface MySessionScopedApi {
         @GET
         public Response get();


### PR DESCRIPTION
… implementation.  Fixes some minor formatting as well in the builder.

Make the wiremock server a once per test class instance, to ensure its been setup (its fine to reuse it).

Fix some remaining missing annotations on API interfaces.

Resolves #44