### PR TITLE
Use status and headers instead of Response in handles() method (#42)

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/rest/client/ext/ResponseExceptionMapper.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/ext/ResponseExceptionMapper.java
@@ -18,6 +18,7 @@ package org.eclipse.microprofile.rest.client.ext;
 
 import javax.annotation.Priority;
 import javax.ws.rs.Priorities;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 
 /**
@@ -40,15 +41,14 @@ public interface ResponseExceptionMapper<T extends Throwable> {
 
     /**
      * Whether or not this mapper will be used for the given response.  By default, any response code of 400 or higher will be handled.
-     * Individual mappers may override this method if they want to more narrowly focus on certain response codes.
+     * Individual mappers may override this method if they want to more narrowly focus on certain response codes or headers.
      *
-     * If this method reads the response body as a stream it must ensure that it resets the stream.
-     *
-     * @param response the JAX-RS Response object that was received
+     * @param status the response status code indicating the HTTP response
+     * @param headers the headers from the HTTP response
      * @return whether or not this mapper can convert the Response to a Throwable
      */
-    default boolean handles(Response response) {
-        return response.getStatus() >= 400;
+    default boolean handles(int status, MultivaluedMap<String, Object> headers) {
+        return status >= 400;
     }
 
     /**

--- a/spec/src/main/asciidoc/providers.asciidoc
+++ b/spec/src/main/asciidoc/providers.asciidoc
@@ -49,13 +49,13 @@ The `WriterInterceptor` interface is a listener for when a write occurs to the s
 
 === ResponseExceptionMapper
 
-The `ResponseExceptionMapper` is specific to MicroProfile Rest Client.  This mapper will take a `Response` object retrieved via an invocation of a client and convert it to a `Throwable`, if applicable.  The runtime should scan all of the registered mappers, sort them ascending based on `getPriority()`, find the ones that can handle the given `Response`, and invoke them.  The first one discovered where `toThrowable` returns a non-null `Throwable` that can be thrown given the client method's signature will be thrown by the runtime.
+The `ResponseExceptionMapper` is specific to MicroProfile Rest Client.  This mapper will take a `Response` object retrieved via an invocation of a client and convert it to a `Throwable`, if applicable.  The runtime should scan all of the registered mappers, sort them ascending based on `getPriority()`, find the ones that can handle the given status code and response headers, and invoke them.  The first one discovered where `toThrowable` returns a non-null `Throwable` that can be thrown given the client method's signature will be thrown by the runtime.
 
 ==== How to Implement ResponseExceptionMapper
 
-The specification provides default methods for `getPriority()` and `handles(Response)` methods.  Priority is meant to be derived via a `@Priority` annotation added to the `ResponseExceptionMapper` implementation.  The runtime will sort ascending, taking the one with the lowest numeric value first to check if it can handle the `Response` object.  The usage of ascending sorting is done to be consistent with JAX-RS behavior.
+The specification provides default methods for `getPriority()` and `handles(int status, MultivaluedMap<String,Object> headers)` methods.  Priority is meant to be derived via a `@Priority` annotation added to the `ResponseExceptionMapper` implementation.  The runtime will sort ascending, taking the one with the lowest numeric value first to check if it can handle the `Response` object based on it's status code and headers.  The usage of ascending sorting is done to be consistent with JAX-RS behavior.
 
-Likewise, the `handles` method by default will handle any response code >= 400.  You may override this behavior if you so choose to handle other response codes (both a smaller ranger and a larger range are expected).  If an implementation reads the body, it must properly reset the underlying stream.
+Likewise, the `handles` method by default will handle any response status code >= 400.  You may override this behavior if you so choose to handle other response codes (both a smaller ranger and a larger range are expected) or base the decision on the response headers.
 
 The `toThrowable(Response)` method actually does the conversion work.  This method should not raise any `Throwable`, instead just return a `Throwable` if it can.  This method may return `null` if no throwable should be raised.  If this method returns a non-null throwable that is a sub-class of RuntimeException or Error (i.e. unchecked throwables), then this exception will be thrown to the client.  Otherwise, the (checked) exception will only be thrown to the client if the client method declares that it throws that type of exception (or a super-class).  For example, assume there is a client interface like this:
 [source, java]
@@ -82,7 +82,7 @@ public class MyResponseExceptionMapper implements ResponseExceptionMapper<SomeEx
 }
 ----
 
-In this case, if the `get` method results in an exception (response status code of 400 or higher), SomeException will be thrown.  If the `put` method results in an exception, SomeException will not be thrown because it does not declare that it throws SomeException.  If another ResponseExceptionMapper (such as the default mapper, see below) is registered that returns a subclass of RuntimeException or Error, then that exception will be thrown.
+In this case, if the `get` method results in an exception (response status code of 400 or higher), SomeException will be thrown.  If the `put` method results in an exception, SomeException will not be thrown because the method does not declare that it throws SomeException.  If another ResponseExceptionMapper (such as the default mapper, see below) is registered that returns a subclass of RuntimeException or Error, then that exception will be thrown.
 
 Any methods that read the response body as a stream must ensure that they reset the stream.
 

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ExceptionMapperTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ExceptionMapperTest.java
@@ -52,7 +52,8 @@ public class ExceptionMapperTest extends WiremockArquillianTest{
     public void resetHandlers() {
         TestResponseExceptionMapper.reset();
         TestResponseExceptionMapperOverridePriority.reset();
-        stubFor(get(urlEqualTo("/")).willReturn(aResponse().withBody("body is ignored in this test")));
+        stubFor(get(urlEqualTo("/")).willReturn(aResponse().withHeader("CustomHeader", "true")
+            .withBody("body is ignored in this test")));
     }
 
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/LowerPriorityTestResponseExceptionMapper.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/LowerPriorityTestResponseExceptionMapper.java
@@ -23,6 +23,7 @@ import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
 import javax.annotation.Priority;
 import javax.ws.rs.Priorities;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 
 @Priority(Priorities.USER - 1)
@@ -36,9 +37,9 @@ public class LowerPriorityTestResponseExceptionMapper implements ResponseExcepti
     }
 
     @Override
-    public boolean handles(Response response) {
+    public boolean handles(int status, MultivaluedMap<String,Object> headers) {
         handlesCalled = true;
-        return response.getStatus() >= 400;
+        return status >= 400;
     }
 
     public static void reset() {

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TestResponseExceptionMapper.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TestResponseExceptionMapper.java
@@ -23,13 +23,16 @@ import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
 import javax.annotation.Priority;
 import javax.ws.rs.Priorities;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 
 @Priority(Priorities.USER + 2)
 public class TestResponseExceptionMapper implements ResponseExceptionMapper<Throwable> {
     public static final String MESSAGE = "A 200 OK was received, but I'm throwing an exception";
     private static boolean handlesCalled = false;
+    private static boolean headerPassedToHandlesMethod = false;
     private static boolean throwableCalled = false;
+
     @Override
     public Throwable toThrowable(Response response) {
         throwableCalled = true;
@@ -37,18 +40,24 @@ public class TestResponseExceptionMapper implements ResponseExceptionMapper<Thro
     }
 
     @Override
-    public boolean handles(Response response) {
+    public boolean handles(int status, MultivaluedMap<String,Object> headers) {
         handlesCalled = true;
-        return response.getStatus() == 200;
+        headerPassedToHandlesMethod = "true".equals(headers.getFirst("CustomHeader"));
+        return status == 200;
     }
 
     public static void reset() {
         handlesCalled = false;
+        headerPassedToHandlesMethod = false;
         throwableCalled = false;
     }
 
     public static boolean isHandlesCalled() {
         return handlesCalled;
+    }
+
+    public static boolean isHeaderPassedToHandlesMethod() {
+      return headerPassedToHandlesMethod;
     }
 
     public static boolean isThrowableCalled() {

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TestResponseExceptionMapperHandles.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TestResponseExceptionMapperHandles.java
@@ -22,6 +22,7 @@ import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
 
 import javax.annotation.Priority;
 import javax.ws.rs.Priorities;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 
 @Priority(Priorities.USER + 1)
@@ -35,7 +36,7 @@ public class TestResponseExceptionMapperHandles implements ResponseExceptionMapp
     }
 
     @Override
-    public boolean handles(Response response) {
+    public boolean handles(int status, MultivaluedMap<String,Object> headers) {
         handlesCalled = true;
         return true;
     }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TestResponseExceptionMapperOverridePriority.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TestResponseExceptionMapperOverridePriority.java
@@ -21,6 +21,7 @@ package org.eclipse.microprofile.rest.client.tck.providers;
 import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
 
 import javax.ws.rs.Priorities;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 
 public class TestResponseExceptionMapperOverridePriority implements ResponseExceptionMapper<Throwable> {
@@ -34,7 +35,7 @@ public class TestResponseExceptionMapperOverridePriority implements ResponseExce
     }
 
     @Override
-    public boolean handles(Response response) {
+    public boolean handles(int status, MultivaluedMap<String,Object> headers) {
         handlesCalled = true;
         return false;
     }


### PR DESCRIPTION

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>