### PR TITLE
Issue #12: New TCK tests clarifying different interfaces

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/BeanParamTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/BeanParamTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.tck.interfaces.InterfaceUsingBeanParam;
+import org.eclipse.microprofile.rest.client.tck.interfaces.MyBean;
+import org.eclipse.microprofile.rest.client.tck.providers.BeanParamFilter;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.core.Response;
+
+import java.net.URL;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class BeanParamTest extends Arquillian{
+    @Deployment
+    public static Archive<?> createDeployment() {
+        return ShrinkWrap.create(WebArchive.class)
+            .addPackage(BeanParamFilter.class.getPackage());
+    }
+
+    @Test
+    public void sendsParamsSpecifiedInBeanParam() throws Exception {
+        BeanParamFilter filter = new BeanParamFilter();
+        RestClientBuilder builder = RestClientBuilder.newBuilder().register(filter);
+        InterfaceUsingBeanParam client = builder.baseUrl(new URL("http://localhost/stub")).build(InterfaceUsingBeanParam.class);
+
+        MyBean myBean = new MyBean("qParam", "123", "headerVal");
+        Response response = client.executePut(myBean);
+        assertEquals(response.getStatus(), 200, "Unexpected response - filter not properly registered");
+        String responseStr = response.readEntity(String.class);
+        assertNotNull(responseStr, "Null entity returned from filter/server");
+        assertTrue(responseStr.contains("qParam"), "QueryParam value not sent in request");
+        assertTrue(responseStr.contains("123"), "CookieParam value not sent in request");
+        assertTrue(responseStr.contains("headerVal"), "QueryParam value not sent in request");
+
+        myBean.setCookie("456");
+        response = client.executePut(myBean);
+        assertEquals(response.getStatus(), 200, "Unexpected response - filter not properly registered");
+        responseStr = response.readEntity(String.class);
+        assertNotNull(responseStr, "Null entity returned from filter/server");
+        assertTrue(responseStr.contains("qParam"), "QueryParam value not sent in second request");
+        assertTrue(responseStr.contains("456"), "CookieParam value not sent in second request");
+        assertTrue(responseStr.contains("headerVal"), "QueryParam value not sent in second request");
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/CustomHttpMethodTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/CustomHttpMethodTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.tck.interfaces.CustomHttpMethod;
+import org.eclipse.microprofile.rest.client.tck.providers.CustomHttpMethodFilter;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.core.Response;
+
+import java.net.URL;
+
+import static org.testng.Assert.assertEquals;
+
+public class CustomHttpMethodTest extends Arquillian{
+    @Deployment
+    public static Archive<?> createDeployment() {
+        return ShrinkWrap.create(WebArchive.class)
+            .addPackage(CustomHttpMethodFilter.class.getPackage());
+    }
+
+    @Test
+    public void invokesUserDefinedHttpMethod() throws Exception {
+        CustomHttpMethodFilter filter = new CustomHttpMethodFilter();
+        RestClientBuilder builder = RestClientBuilder.newBuilder().register(filter);
+        CustomHttpMethod client = builder.baseUrl(new URL("http://localhost/stub")).build(CustomHttpMethod.class);
+        Response response = client.executeMyMethod();
+        assertEquals(response.getStatus(), 200, "Unexpected HTTP Method sent from client - " +
+            "expected \"MYMETHOD\", was \"" + response.readEntity(String.class) + "\"");
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InheritanceTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InheritanceTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.tck.interfaces.BaseClient;
+import org.eclipse.microprofile.rest.client.tck.interfaces.ChildClient;
+import org.eclipse.microprofile.rest.client.tck.providers.ReturnWithURLRequestFilter;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.core.Response;
+
+import java.net.URL;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class InheritanceTest extends Arquillian{
+    @Deployment
+    public static Archive<?> createDeployment() {
+        return ShrinkWrap.create(WebArchive.class)
+            .addPackage(ReturnWithURLRequestFilter.class.getPackage());
+    }
+
+    @Test
+    public void canInvokeMethodOnBaseInterface() throws Exception {
+        ReturnWithURLRequestFilter filter = new ReturnWithURLRequestFilter();
+        RestClientBuilder builder = RestClientBuilder.newBuilder().register(filter);
+        BaseClient client = builder.baseUrl(new URL("http://localhost/stub")).build(ChildClient.class);
+        Response response = client.executeBaseGet();
+        assertEquals(response.getStatus(), 200, "Unexpected response status code");
+        String responseStr = response.readEntity(String.class);
+        assertNotNull(responseStr, "Response entity is null");
+        assertTrue(responseStr.contains("GET ") && responseStr.contains("/base"),
+            "Did not invoke expected method/URI. Expected GET .../base ; got " + responseStr);
+    }
+
+    @Test
+    public void canInvokeMethodOnChildInterface() throws Exception {
+        ReturnWithURLRequestFilter filter = new ReturnWithURLRequestFilter();
+        RestClientBuilder builder = RestClientBuilder.newBuilder().register(filter);
+        ChildClient client = builder.baseUrl(new URL("http://localhost/stub")).build(ChildClient.class);
+        Response response = client.executeChildGet();
+        assertEquals(response.getStatus(), 200, "Unexpected response status code");
+        String responseStr = response.readEntity(String.class);
+        assertNotNull(responseStr, "Response entity is null");
+        assertTrue(responseStr.contains("GET ") && responseStr.contains("/child"),
+            "Did not invoke expected method/URI. Expected GET .../child ; got " + responseStr);
+    }
+
+    @Test
+    public void canInvokeOverriddenMethodOnChildInterface() throws Exception {
+        ReturnWithURLRequestFilter filter = new ReturnWithURLRequestFilter();
+        RestClientBuilder builder = RestClientBuilder.newBuilder().register(filter);
+        BaseClient client = builder.baseUrl(new URL("http://localhost/stub")).build(ChildClient.class);
+        Response response = client.executeBasePost();
+        assertEquals(response.getStatus(), 200, "Unexpected response status code");
+        String responseStr = response.readEntity(String.class);
+        assertNotNull(responseStr, "Response entity is null");
+        assertTrue(responseStr.contains("POST ") && responseStr.contains("/childOverride"),
+            "Did not invoke expected method/URI. Expected POST .../childOverride ; got " + responseStr);
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/SubResourceTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/SubResourceTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.tck.interfaces.RootResource;
+import org.eclipse.microprofile.rest.client.tck.interfaces.SubResource;
+import org.eclipse.microprofile.rest.client.tck.providers.ReturnWithURLRequestFilter;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.core.Response;
+
+import java.net.URL;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class SubResourceTest extends Arquillian{
+    @Deployment
+    public static Archive<?> createDeployment() {
+        return ShrinkWrap.create(WebArchive.class)
+            .addPackage(ReturnWithURLRequestFilter.class.getPackage());
+    }
+
+    @Test
+    public void canInvokeMethodOnSubResourceInterface() throws Exception {
+        ReturnWithURLRequestFilter filter = new ReturnWithURLRequestFilter();
+        RestClientBuilder builder = RestClientBuilder.newBuilder().register(filter);
+        RootResource client = builder.baseUrl(new URL("http://localhost/stub")).build(RootResource.class);
+        SubResource subClient = client.sub();
+        assertNotNull(subClient, "SubResource interface is null");
+        Response response = subClient.getFromSub();
+        assertEquals(response.getStatus(), 200, "Unexpected response status code");
+        String responseStr = response.readEntity(String.class);
+        assertNotNull(responseStr, "Response entity is null");
+        assertTrue(responseStr.contains("GET ") && responseStr.contains("/root/sub"),
+            "Did not invoke expected method/URI. Expected GET .../root/sub ; got " + responseStr);
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/BaseClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/BaseClient.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.POST;
+import javax.ws.rs.core.Response;
+
+public interface BaseClient {
+    @GET
+    @Path("/base")
+    Response executeBaseGet();
+
+    @POST
+    @Path("/base")
+    Response executeBasePost();
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/ChildClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/ChildClient.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.POST;
+import javax.ws.rs.core.Response;
+
+public interface ChildClient extends BaseClient {
+
+    @GET
+    @Path("/child")
+    Response executeChildGet();
+
+    @Override
+    @POST
+    @Path("/childOverride")
+    Response executeBasePost();
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/CustomHttpMethod.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/CustomHttpMethod.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+@Path("/custom")
+public interface CustomHttpMethod {
+    @Target({ElementType.METHOD})
+    @Retention(RetentionPolicy.RUNTIME)
+    @HttpMethod("MYMETHOD")
+    public static @interface MYMETHOD {
+    }
+
+    @MYMETHOD
+    Response executeMyMethod();
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/InterfaceUsingBeanParam.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/InterfaceUsingBeanParam.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.PUT;
+import javax.ws.rs.core.Response;
+
+@Path("/root")
+public interface InterfaceUsingBeanParam {
+    @PUT
+    @Path("/beanParam")
+    Response executePut(@BeanParam MyBean bean);
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/MyBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/MyBean.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+import javax.ws.rs.CookieParam;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.QueryParam;
+
+public class MyBean {
+    @QueryParam("query")
+    private String query;
+
+    @CookieParam("cookie")
+    private String cookie;
+
+    @HeaderParam("MyHeader")
+    private String header;
+
+    public MyBean(String query, String cookie, String header) {
+        this.query = query;
+        this.cookie = cookie;
+        this.header = header;
+    }
+
+    public String getQuery() {
+        return query;
+    }
+
+    public void setQuery(String query) {
+        this.query = query;
+    }
+
+    public String getCookie() {
+        return cookie;
+    }
+
+    public void setCookie(String cookie) {
+        this.cookie = cookie;
+    }
+
+    public String getHeader() {
+        return header;
+    }
+
+    public void setHeader(String header) {
+        this.header = header;
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/RootResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/RootResource.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+import javax.ws.rs.Path;
+
+@Path("/root")
+public interface RootResource {
+
+    @Path("/sub")
+    SubResource sub();
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/SubResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/SubResource.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.core.Response;
+
+public interface SubResource {
+
+    @GET
+    Response getFromSub();
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/BeanParamFilter.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/BeanParamFilter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.providers;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+
+public class BeanParamFilter implements ClientRequestFilter {
+
+    @Override
+    public void filter(ClientRequestContext clientRequestContext) throws IOException {
+        String query = clientRequestContext.getUri().getQuery();
+        Cookie cookie = clientRequestContext.getCookies().get("cookie");
+        String cookieValue = cookie==null?"null":cookie.getValue();
+        String header = clientRequestContext.getHeaderString("MyHeader");
+        clientRequestContext.abortWith(Response.ok(query + " " + cookieValue + " " + header).build());
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/CustomHttpMethodFilter.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/CustomHttpMethodFilter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.providers;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+
+public class CustomHttpMethodFilter implements ClientRequestFilter {
+
+    @Override
+    public void filter(ClientRequestContext clientRequestContext) throws IOException {
+        String httpMethod = clientRequestContext.getMethod();
+        if ("MYMETHOD".equals(httpMethod)) {
+            clientRequestContext.abortWith(Response.ok().build());
+        }
+        else {
+            clientRequestContext.abortWith(Response.status(405).entity(httpMethod).build());
+        }
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/ReturnWithURLRequestFilter.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/ReturnWithURLRequestFilter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.providers;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+
+public class ReturnWithURLRequestFilter implements ClientRequestFilter {
+
+    @Override
+    public void filter(ClientRequestContext clientRequestContext) throws IOException {
+        clientRequestContext.abortWith(Response.ok(clientRequestContext.getMethod() + " " + clientRequestContext.getUri()).build());
+
+    }
+}


### PR DESCRIPTION
New tests for:
* Sub resource interfaces
* `@BeanParam` usage
* Interface inheritance
* Custom HTTP methods

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>