### PR TITLE
[#76] Add new baseUri method

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -32,19 +32,19 @@ service like this:
  public interface MovieReviewService {
      @GET
      Set<Movie> getAllMovies();
-     
+
      @GET
      @Path("/{movieId}/reviews")
      Set<Review> getAllReviews( @PathParam("movieId") String movieId );
-     
+
      @GET
      @Path("/{movieId}/reviews/{reviewId}"
      Review getReview( @PathParam("movieId") String movieId, @PathParam("reviewId") String reviewId );
-     
+
      @POST
      @Path("/{movieId}/reviews")
      String submitReview( @PathParam("movieId") String movieId, Review review );
-     
+
      @PUT
      @Path("/{movieId}/reviews/{reviewId}"
      Review updateReview( @PathParam("movieId") String movieId, @PathParam("reviewId") String reviewId, Review review );
@@ -53,18 +53,18 @@ service like this:
 
 Now we can use this interface as a means to invoke the actual remote review service like this:
 ```java
-String apiUrl = "http://localhost:9080/movieReviewService";
+URI apiUri = new URI("http://localhost:9080/movieReviewService");
 MovieReviewService reviewSvc = RestClientBuilder.newBuilder()
-            .baseUrl(apiUrl)
+            .baseUri(apiUri)
             .build(MovieReviewService.class);
 Review review = new Review(3 /* stars */, "This was a delightful comedy, but not terribly realistic.");
 reviewSvc.submitReview( movieId, review );
 ```
 
-This allows for a much more natural coding style, and the underlying MicroProfile implementation handles the communication 
-between the client and service - it makes the HTTP connection, serializes the Review object to JSON/XML/etc. so that the 
+This allows for a much more natural coding style, and the underlying MicroProfile implementation handles the communication
+between the client and service - it makes the HTTP connection, serializes the Review object to JSON/XML/etc. so that the
 remote service can process it.
 
-This project is creating a specification for REST clients. It does not provide an implementation. Various vendors are 
-involved in this project and will provide their own implementation of this specification. This project is still under 
+This project is creating a specification for REST clients. It does not provide an implementation. Various vendors are
+involved in this project and will provide their own implementation of this specification. This project is still under
 development - participation welcome!

--- a/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
@@ -16,6 +16,7 @@
 package org.eclipse.microprofile.rest.client;
 
 import javax.ws.rs.core.Configurable;
+import java.net.URI;
 import java.net.URL;
 import org.eclipse.microprofile.rest.client.spi.RestClientBuilderResolver;
 
@@ -50,10 +51,35 @@ public interface RestClientBuilder extends Configurable<RestClientBuilder> {
      * <code>http://my-service:8080/service/api</code> in addition to any
      * <code>@Path</code> annotations included on the method.
      *
+     * The {@link #baseUri(URI)} method should be preferred over this method.
+     *
+     * Subsequent calls to this method will replace the previously specified
+     * baseUri/baseUrl.
+     *
      * @param url the base Url for the service.
      * @return the current builder with the baseUrl set
+     * @deprecated use {@link #baseUri(java.net.URI)} instead.
      */
+    @Deprecated
     RestClientBuilder baseUrl(URL url);
+
+    /**
+     * Specifies the base URI to be used when making requests. Assuming that the
+     * interface has a <code>@Path("/api")</code> at the interface level and a
+     * <code>uri</code> is given with
+     * <code>http://my-service:8080/service</code> then all REST calls will be
+     * invoked with a <code>uri</code> of
+     * <code>http://my-service:8080/service/api</code> in addition to any
+     * <code>@Path</code> annotations included on the method.
+     *
+     * Subsequent calls to this method will replace the previously specified
+     * baseUri/baseUrl.
+     *
+     * @param uri the base URI for the service.
+     * @return the current builder with the baseUri set
+     * @since 1.1
+     */
+    RestClientBuilder baseUri(URI uri);
 
     /**
      * Based on the configured RestClientBuilder, creates a new instance of the
@@ -63,8 +89,8 @@ public interface RestClientBuilder extends Configurable<RestClientBuilder> {
      * @param <T> the type of the interface
      * @return a new instance of an implementation of this REST interface that
      * @throws IllegalStateException if not all pre-requisites are satisfied for
-     * the builder, this exception may get thrown. For instance, if a URL has
-     * not been set.
+     * the builder, this exception may get thrown. For instance, if the base
+     * URI/URL has not been set.
      * @throws RestClientDefinitionException if the passed-in interface class is
      * invalid.
      */

--- a/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
@@ -16,6 +16,7 @@
 package org.eclipse.microprofile.rest.client;
 
 import javax.ws.rs.core.Configurable;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import org.eclipse.microprofile.rest.client.spi.RestClientBuilderResolver;
@@ -51,16 +52,12 @@ public interface RestClientBuilder extends Configurable<RestClientBuilder> {
      * <code>http://my-service:8080/service/api</code> in addition to any
      * <code>@Path</code> annotations included on the method.
      *
-     * The {@link #baseUri(URI)} method should be preferred over this method.
-     *
      * Subsequent calls to this method will replace the previously specified
      * baseUri/baseUrl.
      *
      * @param url the base Url for the service.
      * @return the current builder with the baseUrl set
-     * @deprecated use {@link #baseUri(java.net.URI)} instead.
      */
-    @Deprecated
     RestClientBuilder baseUrl(URL url);
 
     /**
@@ -77,9 +74,17 @@ public interface RestClientBuilder extends Configurable<RestClientBuilder> {
      *
      * @param uri the base URI for the service.
      * @return the current builder with the baseUri set
+     * @throws IllegalArgumentException if the passed in URI is invalid
      * @since 1.1
      */
-    RestClientBuilder baseUri(URI uri);
+    default RestClientBuilder baseUri(URI uri) {
+        try {
+            return baseUrl(uri.toURL());
+        }
+        catch (MalformedURLException ex) {
+            throw new IllegalArgumentException(ex);
+        }
+    }
 
     /**
      * Based on the configured RestClientBuilder, creates a new instance of the

--- a/api/src/test/java/org/eclipse/microprofile/rest/client/BuilderImpl1.java
+++ b/api/src/test/java/org/eclipse/microprofile/rest/client/BuilderImpl1.java
@@ -17,12 +17,18 @@
 package org.eclipse.microprofile.rest.client;
 
 import javax.annotation.Priority;
+import java.net.URI;
 import java.net.URL;
 
 @Priority(1)
 public class BuilderImpl1 extends AbstractBuilder {
     @Override
     public RestClientBuilder baseUrl(URL url) {
+        throw new IllegalStateException("not implemented");
+    }
+
+    @Override
+    public RestClientBuilder baseUri(URI uri) {
         throw new IllegalStateException("not implemented");
     }
 

--- a/api/src/test/java/org/eclipse/microprofile/rest/client/BuilderImpl2.java
+++ b/api/src/test/java/org/eclipse/microprofile/rest/client/BuilderImpl2.java
@@ -17,12 +17,18 @@
 package org.eclipse.microprofile.rest.client;
 
 import javax.annotation.Priority;
+import java.net.URI;
 import java.net.URL;
 
 @Priority(2)
 public class BuilderImpl2 extends AbstractBuilder {
     @Override
     public RestClientBuilder baseUrl(URL url) {
+        throw new IllegalStateException("not implemented");
+    }
+
+    @Override
+    public RestClientBuilder baseUri(URI uri) {
         throw new IllegalStateException("not implemented");
     }
 

--- a/spec/src/main/asciidoc/cdi.asciidoc
+++ b/spec/src/main/asciidoc/cdi.asciidoc
@@ -74,13 +74,15 @@ public interface MyServiceClient {
 
 The values of the following properties will be provided via MicroProfile Config:
 
-- `com.mycompany.remoteServices.MyServiceClient/mp-rest/url`: The base URL to use for this service, the equivalent of the `baseUri` method.  This property is considered required, however implementations may have other ways to define these URLs.
+- `com.mycompany.remoteServices.MyServiceClient/mp-rest/url`: The base URL to use for this service, the equivalent of the `baseUrl` method.  This property (or */mp-rest/uri) is considered required, however implementations may have other ways to define these URLs/URIs.
+- `com.mycompany.remoteServices.MyServiceClient/mp-rest/uri`: The base URI to use for this service, the equivalent of the `baseUri` method.  This property (or */mp-rest/url) is considered required, however implementations may have other ways to define these URLs/URIs.
 - `com.mycompany.remoteServices.MyServiceClient/mp-rest/scope`: The fully qualified classname to a CDI scope to use for injection, defaults to `javax.enterprise.context.Dependent` as mentioned above.
 - `com.mycompany.remoteServices.MyServiceClient/mp-rest/providers`: A comma separated list of fully-qualified provider classnames to include in the client, the equivalent of the `register` method or the `@RegisterProvider` annotation.
 - `com.mycompany.remoteServices.MyServiceClient/mp-rest/providers/com.mycompany.MyProvider/priority` will override the priority of the provider for this interface.
 
 Implementations may support other custom properties registered in similar fashions or other ways.
 
-The `url` property must resolve to a value that can be parsed by the `URL` converter required by the MicroProfile Config spec.
+The `url` property must resolve to a value that can be parsed by the `URL` converter required by the MicroProfile Config spec. Likewise, the `uri` property must resolve to a value that can be parsed by the `URI` converter.
+If both the `url` and `uri` properties are declared, then the `uri` property will take precedence.
 
 The `providers` property is not aggregated, the value will be read from the highest property `ConfigSource`

--- a/spec/src/main/asciidoc/cdi.asciidoc
+++ b/spec/src/main/asciidoc/cdi.asciidoc
@@ -74,7 +74,7 @@ public interface MyServiceClient {
 
 The values of the following properties will be provided via MicroProfile Config:
 
-- `com.mycompany.remoteServices.MyServiceClient/mp-rest/url`: The base URL to use for this service, the equivalent of the `baseUrl` method.  This property is considered required, however implementations may have other ways to define these URLs.
+- `com.mycompany.remoteServices.MyServiceClient/mp-rest/url`: The base URL to use for this service, the equivalent of the `baseUri` method.  This property is considered required, however implementations may have other ways to define these URLs.
 - `com.mycompany.remoteServices.MyServiceClient/mp-rest/scope`: The fully qualified classname to a CDI scope to use for injection, defaults to `javax.enterprise.context.Dependent` as mentioned above.
 - `com.mycompany.remoteServices.MyServiceClient/mp-rest/providers`: A comma separated list of fully-qualified provider classnames to include in the client, the equivalent of the `register` method or the `@RegisterProvider` annotation.
 - `com.mycompany.remoteServices.MyServiceClient/mp-rest/providers/com.mycompany.MyProvider/priority` will override the priority of the provider for this interface.

--- a/spec/src/main/asciidoc/programmatic_lookup.asciidoc
+++ b/spec/src/main/asciidoc/programmatic_lookup.asciidoc
@@ -24,13 +24,13 @@ Type Safe Rest Clients support both programmatic look up and CDI injection appro
 [source, java]
 ----
 public class SomeService {
-   public Response doWorkAgainstApi(URL apiUrl, ApiModel apiModel) {
+   public Response doWorkAgainstApi(URI apiUri, ApiModel apiModel) {
        RemoteApi remoteApi = RestClientBuilder.newBuilder()
-            .baseUrl(apiUrl)
+            .baseUri(apiUri)
             .build(RemoteApi.class);
        return remoteApi.execute(apiModel);
    }
 }
 ----
 
-Specifying the `baseUrl` is the URL to the remote service.  The `proxy` method takes an interface that defines one or more API methods to be invoked, returning back an instance of that interface that can be used to perform API calls.
+Specifying the `baseUri` is the URI to the remote service.  The `proxy` method takes an interface that defines one or more API methods to be invoked, returning back an instance of that interface that can be used to perform API calls.

--- a/spec/src/main/asciidoc/release_notes.asciidoc
+++ b/spec/src/main/asciidoc/release_notes.asciidoc
@@ -23,7 +23,7 @@
 
 Changes since 1.0:
 
-- New `baseUri` method on `RestClientBuilder` - this is preferred over the now-deprecated `baseUrl` method.
+- New `baseUri` method on `RestClientBuilder`.
 
 
 [[release_notes_10]]

--- a/spec/src/main/asciidoc/release_notes.asciidoc
+++ b/spec/src/main/asciidoc/release_notes.asciidoc
@@ -16,7 +16,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // Contributors:
-// John D. Ament
+// John D. Ament, Andy McCright
+
+[[release_notes_11]]
+== Release Notes for MicroProfile Rest CLient 1.1
+
+Changes since 1.0:
+
+- New `baseUri` method on `RestClientBuilder` - this is preferred over the now-deprecated `baseUrl` method.
+
 
 [[release_notes_10]]
 == Release Notes for MicroProfile Rest Client 1.0
@@ -54,7 +62,7 @@ public interface SimpleGetApi {
 }
 // in your client code
 SimpleGetApi simpleGetApi = RestClientBuilder.newBuilder()
-            .baseUrl(getApplicationUrl())
+            .baseUri(getApplicationUri())
             .build(SimpleGetApi.class);
 ----
 

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/BeanParamTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/BeanParamTest.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
 
 import javax.ws.rs.core.Response;
 
-import java.net.URL;
+import java.net.URI;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -50,7 +50,7 @@ public class BeanParamTest extends Arquillian{
     public void sendsParamsSpecifiedInBeanParam() throws Exception {
         BeanParamFilter filter = new BeanParamFilter();
         RestClientBuilder builder = RestClientBuilder.newBuilder().register(filter);
-        InterfaceUsingBeanParam client = builder.baseUrl(new URL("http://localhost/stub")).build(InterfaceUsingBeanParam.class);
+        InterfaceUsingBeanParam client = builder.baseUri(new URI("http://localhost/stub")).build(InterfaceUsingBeanParam.class);
 
         MyBean myBean = new MyBean("qParam", "123", "headerVal");
         Response response = client.executePut(myBean);

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/CallMultipleMappersTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/CallMultipleMappersTest.java
@@ -52,7 +52,7 @@ public class CallMultipleMappersTest extends WiremockArquillianTest {
         TestResponseExceptionMapperHandles.reset();
         stubFor(get(urlEqualTo("/")).willReturn(aResponse().withBody("body is ignored in this test")));
         SimpleGetApi simpleGetApi = RestClientBuilder.newBuilder()
-            .baseUrl(getServerURL())
+            .baseUri(getServerURI())
             .register(TestResponseExceptionMapper.class)
             .register(TestResponseExceptionMapperHandles.class)
             .build(SimpleGetApi.class);

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/CustomHttpMethodTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/CustomHttpMethodTest.java
@@ -31,7 +31,7 @@ import org.testng.annotations.Test;
 
 import javax.ws.rs.core.Response;
 
-import java.net.URL;
+import java.net.URI;
 
 import static org.testng.Assert.assertEquals;
 
@@ -47,7 +47,7 @@ public class CustomHttpMethodTest extends Arquillian{
     public void invokesUserDefinedHttpMethod() throws Exception {
         CustomHttpMethodFilter filter = new CustomHttpMethodFilter();
         RestClientBuilder builder = RestClientBuilder.newBuilder().register(filter);
-        CustomHttpMethod client = builder.baseUrl(new URL("http://localhost/stub")).build(CustomHttpMethod.class);
+        CustomHttpMethod client = builder.baseUri(new URI("http://localhost/stub")).build(CustomHttpMethod.class);
         Response response = client.executeMyMethod();
         assertEquals(response.getStatus(), 200, "Unexpected HTTP Method sent from client - " +
             "expected \"MYMETHOD\", was \"" + response.readEntity(String.class) + "\"");

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/DefaultExceptionMapperConfigTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/DefaultExceptionMapperConfigTest.java
@@ -53,7 +53,7 @@ public class DefaultExceptionMapperConfigTest extends WiremockArquillianTest {
         stubFor(get(urlEqualTo("/")).willReturn(aResponse().withStatus(STATUS).withBody(BODY)));
 
         SimpleGetApi simpleGetApi = RestClientBuilder.newBuilder()
-            .baseUrl(getServerURL())
+            .baseUri(getServerURI())
             .build(SimpleGetApi.class);
 
         try {

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/DefaultExceptionMapperTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/DefaultExceptionMapperTest.java
@@ -61,7 +61,7 @@ public class DefaultExceptionMapperTest extends WiremockArquillianTest {
         stubFor(get(urlEqualTo("/")).willReturn(aResponse().withStatus(STATUS).withBody(BODY)));
 
         SimpleGetApi simpleGetApi = RestClientBuilder.newBuilder()
-            .baseUrl(getServerURL())
+            .baseUri(getServerURI())
             .property("microprofile.rest.client.disable.default.mapper", true)
             .build(SimpleGetApi.class);
 
@@ -79,7 +79,7 @@ public class DefaultExceptionMapperTest extends WiremockArquillianTest {
         stubFor(get(urlEqualTo("/")).willReturn(aResponse().withStatus(STATUS).withBody(BODY)));
 
         SimpleGetApi simpleGetApi = RestClientBuilder.newBuilder()
-            .baseUrl(getServerURL())
+            .baseUri(getServerURI())
             .build(SimpleGetApi.class);
 
         try {
@@ -103,7 +103,7 @@ public class DefaultExceptionMapperTest extends WiremockArquillianTest {
         stubFor(get(urlEqualTo("/")).willReturn(aResponse().withStatus(STATUS).withBody(BODY)));
 
         SimpleGetApi simpleGetApi = RestClientBuilder.newBuilder()
-            .baseUrl(getServerURL())
+            .baseUri(getServerURI())
             .property("microprofile.rest.client.disable.default.mapper", false)
             .build(SimpleGetApi.class);
 
@@ -120,7 +120,7 @@ public class DefaultExceptionMapperTest extends WiremockArquillianTest {
         stubFor(get(urlEqualTo("/")).willReturn(aResponse().withStatus(STATUS).withBody(BODY)));
 
         SimpleGetApi simpleGetApi = RestClientBuilder.newBuilder()
-            .baseUrl(getServerURL())
+            .baseUri(getServerURI())
             .register(LowerPriorityTestResponseExceptionMapper.class)
             .build(SimpleGetApi.class);
 

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ExceptionMapperTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ExceptionMapperTest.java
@@ -59,7 +59,7 @@ public class ExceptionMapperTest extends WiremockArquillianTest{
         stubFor(get(urlEqualTo("/")).willReturn(aResponse().withHeader("CustomHeader", "true")
             .withBody("body is ignored in this test")));
         SimpleGetApi simpleGetApi = RestClientBuilder.newBuilder()
-            .baseUrl(getServerURL())
+            .baseUri(getServerURI())
             .register(TestResponseExceptionMapper.class)
             .build(SimpleGetApi.class);
 
@@ -82,7 +82,7 @@ public class ExceptionMapperTest extends WiremockArquillianTest{
         stubFor(get(urlEqualTo("/")).willReturn(aResponse().withHeader("CustomHeader", "true")
             .withBody("body is ignored in this test")));
         SimpleGetApi simpleGetApi = RestClientBuilder.newBuilder()
-            .baseUrl(getServerURL())
+            .baseUri(getServerURI())
             .register(TestResponseExceptionMapper.class)
             .register(TestResponseExceptionMapperOverridePriority.class)
             .build(SimpleGetApi.class);

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InheritanceTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InheritanceTest.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
 
 import javax.ws.rs.core.Response;
 
-import java.net.URL;
+import java.net.URI;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -50,7 +50,7 @@ public class InheritanceTest extends Arquillian{
     public void canInvokeMethodOnBaseInterface() throws Exception {
         ReturnWithURLRequestFilter filter = new ReturnWithURLRequestFilter();
         RestClientBuilder builder = RestClientBuilder.newBuilder().register(filter);
-        BaseClient client = builder.baseUrl(new URL("http://localhost/stub")).build(ChildClient.class);
+        BaseClient client = builder.baseUri(new URI("http://localhost/stub")).build(ChildClient.class);
         Response response = client.executeBaseGet();
         assertEquals(response.getStatus(), 200, "Unexpected response status code");
         String responseStr = response.readEntity(String.class);
@@ -63,7 +63,7 @@ public class InheritanceTest extends Arquillian{
     public void canInvokeMethodOnChildInterface() throws Exception {
         ReturnWithURLRequestFilter filter = new ReturnWithURLRequestFilter();
         RestClientBuilder builder = RestClientBuilder.newBuilder().register(filter);
-        ChildClient client = builder.baseUrl(new URL("http://localhost/stub")).build(ChildClient.class);
+        ChildClient client = builder.baseUri(new URI("http://localhost/stub")).build(ChildClient.class);
         Response response = client.executeChildGet();
         assertEquals(response.getStatus(), 200, "Unexpected response status code");
         String responseStr = response.readEntity(String.class);
@@ -76,7 +76,7 @@ public class InheritanceTest extends Arquillian{
     public void canInvokeOverriddenMethodOnChildInterface() throws Exception {
         ReturnWithURLRequestFilter filter = new ReturnWithURLRequestFilter();
         RestClientBuilder builder = RestClientBuilder.newBuilder().register(filter);
-        BaseClient client = builder.baseUrl(new URL("http://localhost/stub")).build(ChildClient.class);
+        BaseClient client = builder.baseUri(new URI("http://localhost/stub")).build(ChildClient.class);
         Response response = client.executeBasePost();
         assertEquals(response.getStatus(), 200, "Unexpected response status code");
         String responseStr = response.readEntity(String.class);

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvalidInterfaceTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvalidInterfaceTest.java
@@ -16,8 +16,7 @@
 
 package org.eclipse.microprofile.rest.client.tck;
 
-import java.io.IOException;
-import java.net.URL;
+import java.net.URI;
 
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.RestClientDefinitionException;
@@ -43,27 +42,27 @@ public class InvalidInterfaceTest extends Arquillian{
     }
 
     @Test(expectedExceptions={RestClientDefinitionException.class})
-    public void testExceptionThrownWhenInterfaceHasMethodWithMultipleHTTPMethodAnnotations() throws IOException {
-        RestClientBuilder.newBuilder().baseUrl(new URL("http://localhost:8080/")).build(MultipleHTTPMethodAnnotations.class);
+    public void testExceptionThrownWhenInterfaceHasMethodWithMultipleHTTPMethodAnnotations() throws Exception {
+        RestClientBuilder.newBuilder().baseUri(new URI("http://localhost:8080/")).build(MultipleHTTPMethodAnnotations.class);
     }
 
     @Test(expectedExceptions={RestClientDefinitionException.class})
-    public void testExceptionThrownWhenInterfaceHasMethodWithMissingPathParamAnnotation_templateDeclaredAtTypeLevel() throws IOException {
-        RestClientBuilder.newBuilder().baseUrl(new URL("http://localhost:8080/")).build(MissingPathParam.class);
+    public void testExceptionThrownWhenInterfaceHasMethodWithMissingPathParamAnnotation_templateDeclaredAtTypeLevel() throws Exception {
+        RestClientBuilder.newBuilder().baseUri(new URI("http://localhost:8080/")).build(MissingPathParam.class);
     }
 
     @Test(expectedExceptions={RestClientDefinitionException.class})
-    public void testExceptionThrownWhenInterfaceHasMethodWithMissingPathParamAnnotation_templateDeclaredAtMethodLevel() throws IOException {
-        RestClientBuilder.newBuilder().baseUrl(new URL("http://localhost:8080/")).build(MissingPathParamSub.class);
+    public void testExceptionThrownWhenInterfaceHasMethodWithMissingPathParamAnnotation_templateDeclaredAtMethodLevel() throws Exception {
+        RestClientBuilder.newBuilder().baseUri(new URI("http://localhost:8080/")).build(MissingPathParamSub.class);
     }
 
     @Test(expectedExceptions={RestClientDefinitionException.class})
-    public void testExceptionThrownWhenInterfaceHasMethodWithPathParamAnnotationButNoURITemplate() throws IOException {
-        RestClientBuilder.newBuilder().baseUrl(new URL("http://localhost:8080/")).build(MissingUriTemplate.class);
+    public void testExceptionThrownWhenInterfaceHasMethodWithPathParamAnnotationButNoURITemplate() throws Exception {
+        RestClientBuilder.newBuilder().baseUri(new URI("http://localhost:8080/")).build(MissingUriTemplate.class);
     }
 
     @Test(expectedExceptions={RestClientDefinitionException.class})
-    public void testExceptionThrownWhenInterfaceHasMethodWithMismatchedPathParameter() throws IOException {
-        RestClientBuilder.newBuilder().baseUrl(new URL("http://localhost:8080/")).build(TemplateMismatch.class);
+    public void testExceptionThrownWhenInterfaceHasMethodWithMismatchedPathParameter() throws Exception {
+        RestClientBuilder.newBuilder().baseUri(new URI("http://localhost:8080/")).build(TemplateMismatch.class);
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeSimpleGetOperationTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeSimpleGetOperationTest.java
@@ -48,7 +48,7 @@ public class InvokeSimpleGetOperationTest extends WiremockArquillianTest{
                 .withBody(expectedBody)));
 
         SimpleGetApi simpleGetApi = RestClientBuilder.newBuilder()
-            .baseUrl(getServerURL())
+            .baseUri(getServerURI())
             .build(SimpleGetApi.class);
 
         Response response = simpleGetApi.executeGet();

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeWithBuiltProvidersTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeWithBuiltProvidersTest.java
@@ -119,7 +119,7 @@ public class InvokeWithBuiltProvidersTest extends WiremockArquillianTest {
             .register(TestParamConverterProvider.class)
             .register(TestReaderInterceptor.class)
             .register(TestWriterInterceptor.class)
-            .baseUrl(getServerURL())
+            .baseUri(getServerURI())
             .build(InterfaceWithoutProvidersDefined.class);
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeWithJsonPProviderTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeWithJsonPProviderTest.java
@@ -70,7 +70,7 @@ public class InvokeWithJsonPProviderTest extends WiremockArquillianTest{
     @BeforeTest
     public void setupClient() throws Exception{
         builtJsonPClient = RestClientBuilder.newBuilder()
-            .baseUrl(getServerURL())
+            .baseUri(getServerURI())
             .build(JsonPClient.class);
     }
 

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeWithRegisteredProvidersTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeWithRegisteredProvidersTest.java
@@ -62,7 +62,7 @@ public class InvokeWithRegisteredProvidersTest extends WiremockArquillianTest {
                 .withBody(outputBody)));
 
         InterfaceWithProvidersDefined api = RestClientBuilder.newBuilder()
-            .baseUrl(getServerURL())
+            .baseUri(getServerURI())
             .build(InterfaceWithProvidersDefined.class);
 
         Response response = api.executePost(inputBody);
@@ -94,7 +94,7 @@ public class InvokeWithRegisteredProvidersTest extends WiremockArquillianTest {
                 .withBody(outputBody)));
 
         InterfaceWithProvidersDefined api = RestClientBuilder.newBuilder()
-            .baseUrl(getServerURL())
+            .baseUri(getServerURI())
             .build(InterfaceWithProvidersDefined.class);
 
         Response response = api.executePut(id, inputBody);

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/MultiRegisteredTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/MultiRegisteredTest.java
@@ -49,7 +49,7 @@ public class MultiRegisteredTest extends WiremockArquillianTest {
         stubFor(get(urlEqualTo("/")).willReturn(aResponse().withStatus(200).withBody("")));
         InterfaceWithoutPriority client = RestClientBuilder.newBuilder().register(UnprioritizedMessageBodyReader.class, 1000)
             .register(Prioritized2000MessageBodyReader.class, 500)
-            .baseUrl(getServerURL())
+            .baseUri(getServerURI())
             .build(InterfaceWithoutPriority.class);
         String body = client.get().readEntity(String.class);
         assertEquals(body, "Prioritized 2000", "The body returned should be the body from "+Prioritized2000MessageBodyReader.class);
@@ -60,7 +60,7 @@ public class MultiRegisteredTest extends WiremockArquillianTest {
         stubFor(get(urlEqualTo("/")).willReturn(aResponse().withStatus(200).withBody("")));
         InterfaceWithPriority client = RestClientBuilder.newBuilder().register(UnprioritizedMessageBodyReader.class, 1000)
             .register(Prioritized2000MessageBodyReader.class, 500)
-            .baseUrl(getServerURL())
+            .baseUri(getServerURI())
             .build(InterfaceWithPriority.class);
         String body = client.get().readEntity(String.class);
         assertEquals(body, "Prioritized 2000", "The body returned should be the body from "+Prioritized2000MessageBodyReader.class);

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/SubResourceTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/SubResourceTest.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
 
 import javax.ws.rs.core.Response;
 
-import java.net.URL;
+import java.net.URI;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -50,7 +50,7 @@ public class SubResourceTest extends Arquillian{
     public void canInvokeMethodOnSubResourceInterface() throws Exception {
         ReturnWithURLRequestFilter filter = new ReturnWithURLRequestFilter();
         RestClientBuilder builder = RestClientBuilder.newBuilder().register(filter);
-        RootResource client = builder.baseUrl(new URL("http://localhost/stub")).build(RootResource.class);
+        RootResource client = builder.baseUri(new URI("http://localhost/stub")).build(RootResource.class);
         SubResource subClient = client.sub();
         assertNotNull(subClient, "SubResource interface is null");
         Response response = subClient.getFromSub();

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/WiremockArquillianTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/WiremockArquillianTest.java
@@ -23,6 +23,8 @@ import org.jboss.arquillian.testng.Arquillian;
 import org.testng.annotations.BeforeClass;
 
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 
 public abstract class WiremockArquillianTest extends Arquillian {
@@ -36,6 +38,15 @@ public abstract class WiremockArquillianTest extends Arquillian {
             setupWireMockConnection();
         }
         return port;
+    }
+
+    protected static URI getServerURI() {
+        try {
+            return new URI(getStringURL());
+        }
+        catch (URISyntaxException e) {
+            throw new RuntimeException("Malformed URI not expected", e);
+        }
     }
 
     protected static URL getServerURL() {

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/CDIURIvsURLConfigTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/CDIURIvsURLConfigTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.cditests;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.eclipse.microprofile.rest.client.tck.WiremockArquillianTest;
+import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.Response;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Verifies that URI declared via MP Config takes precedence over URL.
+ */
+public class CDIURIvsURLConfigTest extends WiremockArquillianTest{
+    @Inject
+    @RestClient
+    private SimpleGetApi api;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        String uriPropertyName = SimpleGetApi.class.getName()+"/mp-rest/uri";
+        String uriValue = getStringURL() + "/uri";
+        String urlPropertyName = SimpleGetApi.class.getName()+"/mp-rest/url";
+        String urlValue = getStringURL() + "/url";
+        String simpleName = CDIInvokeSimpleGetOperationTest.class.getSimpleName();
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, simpleName + ".jar")
+            .addClasses(SimpleGetApi.class, WiremockArquillianTest.class)
+            .addAsManifestResource(new StringAsset(
+                String.format(uriPropertyName+"="+uriValue+"%n"+urlPropertyName+"="+urlValue)),
+                "microprofile-config.properties");
+        return ShrinkWrap.create(WebArchive.class, simpleName + ".war")
+            .addAsLibrary(jar);
+    }
+
+    @Test
+    public void testURItakesPrecedenceOverURL() throws Exception{
+        String expectedBody = "Hello, MicroProfile URI!!";
+        stubFor(get(urlEqualTo("/uri"))
+            .willReturn(aResponse()
+                .withBody(expectedBody)));
+
+        stubFor(get(urlEqualTo("/url"))
+            .willReturn(aResponse()
+                .withBody("Using URL instead of URI")));
+
+        Response response = api.executeGet();
+
+        String body = response.readEntity(String.class);
+
+        response.close();
+
+        assertEquals(body, expectedBody);
+
+        verify(1, getRequestedFor(urlEqualTo("/uri")));
+    }
+}


### PR DESCRIPTION
- Adds new `baseUri` method
- Deprecated `baseUrl` method
- Changing existing tests to call `baseUri`
- New test for ensuring last call to either `baseUri` or `baseUrl` "wins"
- New test for ensuring `RestClientBuilder` throws an `IllegalStateException` if no address was specified.
- Updated release notes to indicate changes

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>