### PR TITLE
Add @Stereotype to @RegisterRestClient

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/rest/client/inject/RegisterRestClient.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/inject/RegisterRestClient.java
@@ -24,6 +24,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Stereotype;
+
 /**
  * A marker annotation to register a rest client at runtime.  This marker must be applied to any CDI managed
  * clients.
@@ -31,5 +34,7 @@ import java.lang.annotation.Target;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Stereotype
+@Dependent
 public @interface RegisterRestClient {
 }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/SimpleGetApi.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/SimpleGetApi.java
@@ -18,13 +18,11 @@ package org.eclipse.microprofile.rest.client.tck.interfaces;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
-import javax.enterprise.context.Dependent;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 
 @Path("/")
-@Dependent
 @RegisterRestClient
 public interface SimpleGetApi {
     @GET


### PR DESCRIPTION
This will ensure that the `@RegisterRestClient` is a bean-defining annotation.

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>