### PR TITLE
Add javadoc to package-info.java

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/rest/client/annotation/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/annotation/package-info.java
@@ -19,7 +19,19 @@
  *******************************************************************************/
 
 /**
+ * APIs for annotating MP Rest Client interfaces.
  *
+ * Example:
+ * <pre>
+ * @RegisterProvider(MyMessageBodyReader.class)
+ * @RegisterProvider(MyMessageBodyWriter.class)
+ * @RegisterProvider(MyClientRequestFilter.class)
+ * public interface MyClientService {
+ *     @GET
+ *     @Path("/myService/{id}")
+ *     Widget getWidget(@PathParam("id") String id);
+ * }
+ * </pre>
  */
 @org.osgi.annotation.versioning.Version("1.0.1")
 package org.eclipse.microprofile.rest.client.annotation;

--- a/api/src/main/java/org/eclipse/microprofile/rest/client/ext/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/ext/package-info.java
@@ -19,7 +19,24 @@
  *******************************************************************************/
 
 /**
+ * APIs for extending MP Rest Client functionality - such as new providers.
+ * Example:
+ * <pre>
+ * public interface MyClientService {
+ *     @GET
+ *     @Path("/myService/{id}")
+ *     Widget getWidget(@PathParam("id") String id) throws UnknownWidgetException;
+ * }
+ * ...
+ * public class UnknownWidgetExceptionMapper implements ResponseExceptionMapper {
  *
+ *     @Override
+ *     UnknownWidgetException toThrowable(Response response) {
+ *         String msg = "Could not find widget with ID of " + response.getHeaderString("WidgetId");
+ *         return new UnknownWidgetException(msg)
+ *     }
+ * }
+ * </pre>
  */
 @org.osgi.annotation.versioning.Version("1.0.1")
 package org.eclipse.microprofile.rest.client.ext;

--- a/api/src/main/java/org/eclipse/microprofile/rest/client/ext/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/ext/package-info.java
@@ -22,6 +22,7 @@
  * APIs for extending MP Rest Client functionality - such as new providers.
  * Example:
  * <pre>
+ * @RegisterProvider(UnknownWidgetExceptionMapper.class)
  * public interface MyClientService {
  *     @GET
  *     @Path("/myService/{id}")

--- a/api/src/main/java/org/eclipse/microprofile/rest/client/inject/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/inject/package-info.java
@@ -19,7 +19,30 @@
  *******************************************************************************/
 
 /**
+ * APIs to aid in CDI-based injection of MP Rest Client implementations.  These
+ * annotations are used both to mark an interface as registered Rest Client and
+ * also to designate that an implementation of that interface should be injected
+ * at a specific injection point.
  *
+ * Example:
+ * <pre>
+ * @RegisterProvider
+ * @Dependent
+ * public interface MyClientService {
+ *     @GET
+ *     @Path("/myService/{id}")
+ *     Widget getWidget(@PathParam("id") String id);
+ * }
+ *
+ * ...
+ * @ApplicationScoped
+ * public class MyBean {
+ *     @Inject
+ *     @RestClient
+ *     MyClientService service;
+ *     ...
+ * }
+ * </pre>
  */
 @org.osgi.annotation.versioning.Version("1.0.1")
 package org.eclipse.microprofile.rest.client.inject;

--- a/api/src/main/java/org/eclipse/microprofile/rest/client/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/package-info.java
@@ -1,6 +1,6 @@
 /*
  *******************************************************************************
- * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -19,8 +19,23 @@
  *******************************************************************************/
 
 /**
- * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>
+ * APIs for building a type-safe RESTful client leveraging existing JAX-RS
+ * APIs, for example:
+ * <pre>
+ * public interface MyClientService {
+ *     @GET
+ *     @Path("/myService/{id}")
+ *     Widget getWidget(@PathParam("id") String id);
+ * }
+ *
+ * ...
+ *
+ * MyClientService service = RestClientBuilder.newBuilder()
+ *                                            .baseUrl(url)
+ *                                            .build();
+ * Widget w = service.getWidget(widgetId); // invokes remote service, returns domain object
+ * </pre>
+ * @since 1.0
  */
 @org.osgi.annotation.versioning.Version("1.0")
 package org.eclipse.microprofile.rest.client;
-

--- a/api/src/main/java/org/eclipse/microprofile/rest/client/spi/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/spi/package-info.java
@@ -19,8 +19,8 @@
  *******************************************************************************/
 
 /**
- * This package provides SPIs for MP Rest Client implementations or system-level
- * components that provide additional functionality for MP Rest Clients.
+ * SPIs for MP Rest Client implementations or system-level components that
+ * provide additional functionality for MP Rest Clients.
  *
  */
 @org.osgi.annotation.versioning.Version("1.0.1")

--- a/api/src/main/java/org/eclipse/microprofile/rest/client/spi/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/spi/package-info.java
@@ -19,6 +19,8 @@
  *******************************************************************************/
 
 /**
+ * This package provides SPIs for MP Rest Client implementations or system-level
+ * components that provide additional functionality for MP Rest Clients.
  *
  */
 @org.osgi.annotation.versioning.Version("1.0.1")


### PR DESCRIPTION
This adds javadoc text with examples to package-info.java files, allowing users and implementors to see more information at the package level.

I am targeting this change toward the 1.0.X-service branch, but it should also go into master.

This will resolve Issue #86.

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>