### PR TITLE
Doc typo fix

### DIFF
--- a/spec/src/main/asciidoc/programmatic_lookup.asciidoc
+++ b/spec/src/main/asciidoc/programmatic_lookup.asciidoc
@@ -33,4 +33,4 @@ public class SomeService {
 }
 ----
 
-Specifying the `baseUrl` is the URL to the remote service.  The `proxy` method takes an interface that defines one or more API methods to be invoked, returning back an instance of that interface that can be used to perform API calls.
+Specifying the `baseUrl` is the URL to the remote service.  The `build` method takes an interface that defines one or more API methods to be invoked, returning back an instance of that interface that can be used to perform API calls.


### PR DESCRIPTION
The api has a 'build' method, but the documentation mentions 'proxy'.

Signed-off-by: Thiago Veronezi <thiago@veronezi.org>