### PR TITLE
Issue #10: Use CompletionStage rather than CompletableFuture

### DIFF
--- a/spec/src/main/asciidoc/async.asciidoc
+++ b/spec/src/main/asciidoc/async.asciidoc
@@ -21,7 +21,7 @@ It is possible for Rest Client interface methods to be declared asynchronous.  T
 
 === Asynchronous Methods
 
-A method is considered to be asynchronous if the method's return type is `java.util.concurrent.CompletableFuture`.
+A method is considered to be asynchronous if the method's return type is `java.util.concurrent.CompletionStage`.
 
 For example, the following methods would be declared asynchronous:
 
@@ -30,11 +30,11 @@ For example, the following methods would be declared asynchronous:
 public interface MyAsyncClient {
     @GET
     @Path("/one")
-    CompletableFuture<Response> get();
+    CompletionStage<Response> get();
 
     @POST
     @Path("/two")
-    CompletableFuture<String> post(String entity);
+    CompletionStage<String> post(String entity);
 }
 ----
 

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/asynctests/AsyncMethodTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/asynctests/AsyncMethodTest.java
@@ -31,7 +31,7 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
@@ -73,7 +73,7 @@ public class AsyncMethodTest extends WiremockArquillianTest{
      * does not match the thread ID of the calling thread.
      */
     @Test
-    public void testInterfaceMethodWithCompletableFutureResponseReturnIsInvokedAsynchronously() throws Exception{
+    public void testInterfaceMethodWithCompletionStageResponseReturnIsInvokedAsynchronously() throws Exception{
         final String expectedBody = "Hello, Async Client!";
         stubFor(get(urlEqualTo("/"))
             .willReturn(aResponse()
@@ -85,9 +85,9 @@ public class AsyncMethodTest extends WiremockArquillianTest{
             .baseUrl(getServerURL())
             .register(ThreadedClientResponseFilter.class)
             .build(SimpleGetApiAsync.class);
-        CompletableFuture<Response> future = api.executeGet();
+        CompletionStage<Response> future = api.executeGet();
 
-        Response response = future.get();
+        Response response = future.toCompletableFuture().get();
         String body = response.readEntity(String.class);
 
         response.close();
@@ -107,7 +107,7 @@ public class AsyncMethodTest extends WiremockArquillianTest{
      * of the calling thread.
      */
     @Test
-    public void testInterfaceMethodWithCompletableFutureObjectReturnIsInvokedAsynchronously() throws Exception{
+    public void testInterfaceMethodWithCompletionStageObjectReturnIsInvokedAsynchronously() throws Exception{
         final String expectedBody = "Hello, Future Async Client!!";
         stubFor(get(urlEqualTo("/string"))
             .willReturn(aResponse()
@@ -120,9 +120,9 @@ public class AsyncMethodTest extends WiremockArquillianTest{
             .baseUrl(getServerURL())
             .register(filter)
             .build(StringResponseClientAsync.class);
-        CompletableFuture<String> future = client.get();
+        CompletionStage<String> future = client.get();
 
-        String body = future.get();
+        String body = future.toCompletableFuture().get();
 
         String responseThreadId = filter.getResponseThreadId();
         assertNotNull(responseThreadId);
@@ -160,9 +160,9 @@ public class AsyncMethodTest extends WiremockArquillianTest{
             .executorService(testExecutorService)
             .build(SimpleGetApiAsync.class);
 
-        CompletableFuture<Response> future = client.executeGet();
+        CompletionStage<Response> future = client.executeGet();
 
-        Response r = future.get();
+        Response r = future.toCompletableFuture().get();
 
         assertEquals(r.readEntity(String.class), expectedBody);
         assertNotEquals(
@@ -197,9 +197,9 @@ public class AsyncMethodTest extends WiremockArquillianTest{
             .register(TLAddPathClientRequestFilter.class)
             .register(aiiFactory)
             .build(SimpleGetApiAsync.class);
-        CompletableFuture<Response> future = api.executeGet();
+        CompletionStage<Response> future = api.executeGet();
 
-        Response response = future.get();
+        Response response = future.toCompletableFuture().get();
         assertEquals(response.getStatus(), 200);
         assertTrue(response.getLocation().getPath().endsWith("/" + threadLocalInt));
 

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/asynctests/CDIInvokeSimpleGetOperationTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/asynctests/CDIInvokeSimpleGetOperationTest.java
@@ -27,7 +27,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.testng.Assert.assertEquals;
 
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.spi.Bean;
@@ -77,9 +77,9 @@ public class CDIInvokeSimpleGetOperationTest extends WiremockArquillianTest{
             .willReturn(aResponse()
                 .withBody(expectedBody)));
 
-        CompletableFuture<Response> future = api.executeGet();
+        CompletionStage<Response> future = api.executeGet();
 
-        Response response = future.get();
+        Response response = future.toCompletableFuture().get();
         String body = response.readEntity(String.class);
 
         response.close();

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/SimpleGetApiAsync.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/SimpleGetApiAsync.java
@@ -16,7 +16,7 @@
 
 package org.eclipse.microprofile.rest.client.tck.interfaces;
 
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -28,5 +28,5 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 @RegisterRestClient
 public interface SimpleGetApiAsync {
     @GET
-    CompletableFuture<Response> executeGet();
+    CompletionStage<Response> executeGet();
 }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/StringResponseClientAsync.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/StringResponseClientAsync.java
@@ -16,7 +16,7 @@
 
 package org.eclipse.microprofile.rest.client.tck.interfaces;
 
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -24,5 +24,5 @@ import javax.ws.rs.Path;
 @Path("/string")
 public interface StringResponseClientAsync {
     @GET
-    CompletableFuture<String> get();
+    CompletionStage<String> get();
 }


### PR DESCRIPTION
Updates to spec and TCK to use the CompletionStage interface
rather than the concrete CompletableFuture class.  This change
was prompted by a discussion in the gitter.im chat.  It more
closely aligns to the JAX-RS 2.1 reactive client APIs as well
as changes proposed in the MP Fault Tolerance spec.

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>