### PR TITLE
Resolve issue where 1.1 TCK tests invoke the same URI twice

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/asynctests/AsyncMethodTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/asynctests/AsyncMethodTest.java
@@ -150,7 +150,7 @@ public class AsyncMethodTest extends WiremockArquillianTest{
     public void testExecutorService() throws Exception{
         final String expectedBody = "Hello, InvocationCallback Async Client!!!";
         final String expectedThreadName = "MPRestClientTCKThread";
-        stubFor(get(urlEqualTo("/"))
+        stubFor(get(urlEqualTo("/execSvc"))
             .willReturn(aResponse()
                 .withBody(expectedBody)));
 
@@ -170,7 +170,7 @@ public class AsyncMethodTest extends WiremockArquillianTest{
             .executorService(testExecutorService)
             .build(SimpleGetApiAsync.class);
 
-        CompletionStage<Response> future = client.executeGet();
+        CompletionStage<Response> future = client.executeGetExecSvc();
 
         Response r = future.toCompletableFuture().get();
 
@@ -182,7 +182,7 @@ public class AsyncMethodTest extends WiremockArquillianTest{
             r.getHeaderString(ThreadedClientResponseFilter.RESPONSE_THREAD_NAME_HEADER),
             expectedThreadName);
 
-        verify(1, getRequestedFor(urlEqualTo("/")));
+        verify(1, getRequestedFor(urlEqualTo("/execSvc")));
     }
 
     /**

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/SimpleGetApiAsync.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/SimpleGetApiAsync.java
@@ -29,4 +29,8 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 public interface SimpleGetApiAsync {
     @GET
     CompletionStage<Response> executeGet();
+
+    @GET
+    @Path("/execSvc")
+    CompletionStage<Response> executeGetExecSvc();
 }


### PR DESCRIPTION
Two TCK methods both check that the "/" URI was executed exactly once - since wiremock does not reset in between test methods, the second test method to execute will always fail. This change uses a different URI for the executorService test to ensure that there is no URI conflicts between tests.

This pull request is agains the 1.1.X-service branch, but the same change should also be made in master.

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>