### PR TITLE
Clarify that @Produces/@Consumes indicates the service view

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/rest/client/inject/RegisterRestClient.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/inject/RegisterRestClient.java
@@ -30,6 +30,9 @@ import javax.enterprise.inject.Stereotype;
 /**
  * A marker annotation to register a rest client at runtime.  This marker must be applied to any CDI managed
  * clients.
+ *
+ * Note that the annotated interface indicates a service-centric view.  Thus users would invoke methods on
+ * this interface as if it were running in the same VM as the remote service.
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/spec/src/main/asciidoc/clientexamples.asciidoc
+++ b/spec/src/main/asciidoc/clientexamples.asciidoc
@@ -78,6 +78,8 @@ public class PutUser {
 
 All built in HTTP methods are supported by the client API.  Likewise, all base parameter types (query, cookie, matrix, path, form and bean) are supported.  If you only need to inspect the body, you can provide a POJO can be processed by the underlying `MessageBodyReader` or `MessageBodyWriter`.  Otherwise, you can receive the entire `Response` object for parsing the body and header information from the server invocation.
 
+Users may specify the media (MIME) type of the outbound request using the `@Consumes` annotation (this determine the `Content-Type` HTTP header), and the expected media type(s) of the response by using the `@Produces` annotation (the `Accept` HTTP header).  This indicates that the client interface expects that the remote _service_ consumes/produces the specified types.
+
 === Invalid Client Interface Examples
 
 Invalid client interfaces will result in a RestClientDefinitionException (which may be wrapped in a `DefinitionException` if using CDI).  Invalid interfaces can include:

--- a/spec/src/main/asciidoc/microprofile-rest-client.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-rest-client.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 Contributors to the Eclipse Foundation
+// Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ProducesConsumesTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ProducesConsumesTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck;
+
+import static org.testng.Assert.assertEquals;
+
+import java.net.URI;
+import java.util.logging.Logger;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.tck.interfaces.ProducesConsumesClient;
+import org.eclipse.microprofile.rest.client.tck.providers.ProducesConsumesFilter;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+public class ProducesConsumesTest extends Arquillian {
+    private final static Logger LOG = Logger.getLogger(ProducesConsumesTest.class.getName());
+
+    @Deployment
+    public static Archive<?> createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, ProducesConsumesTest.class.getSimpleName()+".war")
+            .addClasses(ProducesConsumesClient.class, ProducesConsumesFilter.class);
+    }
+
+    /**
+     * Tests that MP Rest Client's <code>@Produces</code> annotation affects the value transmitted in
+     * the <code>Accept</code> header, and that it's <code>@Consumes</code> annotation affects the
+     * value transmitted in the <code>Content-Type</code> header.  Note that this is opposite of
+     * what you would expect for JAX-RS resources.
+     */
+    @Test
+    public void testProducesConsumesAnnotationOnClientInterface() throws Exception {
+        final String m = "testProducesConsumesAnnotationOnClientInterface";
+        ProducesConsumesClient client = RestClientBuilder.newBuilder()
+                                            .baseUri(URI.create("http://localhost:8080/null"))
+                                            .register(ProducesConsumesFilter.class)
+                                            .build(ProducesConsumesClient.class);
+
+        LOG.info(m + " @Produce(application/json) @Consume(application/xml)");
+        Response r = client.produceJSONConsumeXML();
+        String acceptHeader = r.getHeaderString("Sent-Accept");
+        LOG.info(m + "Sent-Accept: " + acceptHeader);
+        String contentTypeHeader = r.getHeaderString("Sent-ContentType");
+        LOG.info(m + "Sent-ContentType: " + contentTypeHeader);
+        assertEquals(acceptHeader, MediaType.APPLICATION_JSON);
+        assertEquals(contentTypeHeader, MediaType.APPLICATION_XML);
+
+        LOG.info(m + " @Produce(application/xml) @Consume(application/json)");
+        r = client.produceXMLConsumeJSON();
+        acceptHeader = r.getHeaderString("Sent-Accept");
+        LOG.info(m + "Sent-Accept: " + acceptHeader);
+        contentTypeHeader = r.getHeaderString("Sent-ContentType");
+        LOG.info(m + "Sent-ContentType: " + contentTypeHeader);
+        assertEquals(acceptHeader, MediaType.APPLICATION_XML);
+        assertEquals(contentTypeHeader, MediaType.APPLICATION_JSON);
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/ProducesConsumesClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/ProducesConsumesClient.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/producesConsumes")
+public interface ProducesConsumesClient {
+
+    @GET
+    @Produces(MediaType.APPLICATION_XML)
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response produceXMLConsumeJSON();
+
+    @DELETE
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_XML)
+    public Response produceJSONConsumeXML();
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/ProducesConsumesFilter.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/ProducesConsumesFilter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.providers;
+
+import java.io.IOException;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+
+/**
+ * Aborts with a response showing "Sent-Accept" and "Sent-ContentType" headers
+ * to indicate the request's header values for "Accept" and "Content-type",
+ * respectively.
+ */
+public class ProducesConsumesFilter implements ClientRequestFilter {
+    @Override
+    public void filter(ClientRequestContext ctx) throws IOException {
+        String contentType = ctx.getHeaderString(HttpHeaders.CONTENT_TYPE);
+        String accept = ctx.getHeaderString(HttpHeaders.ACCEPT);
+        ctx.abortWith(Response.ok()
+                              .header("Sent-Accept", accept)
+                              .header("Sent-ContentType", contentType)
+                              .build());
+
+    }
+
+}


### PR DESCRIPTION
Clarifies that `@Produces` on a client interface expresses that the remote service produces the specified media type(s), and `@Consumes` expresses the media type(s) that the remote service consumes.

Also, updated the copyright date to 2018.

This resolves issue #109, and partially addresses issues #110 and #113.

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>