### PR TITLE
Update 1.1 release notes and javadocs

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
@@ -112,6 +112,7 @@ public interface RestClientBuilder extends Configurable<RestClientBuilder> {
      * @return the current builder with the executorService set.
      * @throws IllegalArgumentException if the <code>executor</code> parameter is
      * null.
+     * @since 1.1
      */
     RestClientBuilder executorService(ExecutorService executor);
 

--- a/api/src/main/java/org/eclipse/microprofile/rest/client/spi/RestClientBuilderListener.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/spi/RestClientBuilderListener.java
@@ -38,6 +38,8 @@ import org.eclipse.microprofile.rest.client.RestClientBuilder;
  * Note that the <code>onNewBuilder</code> method will be called when the
  * RestClientBuilder is constructed, not when it's <code>build</code> method is
  * invoked.  This allows the caller to override global providers if they desire.
+ *
+ * @since 1.1
  */
 public interface RestClientBuilderListener {
 

--- a/spec/src/main/asciidoc/release_notes.asciidoc
+++ b/spec/src/main/asciidoc/release_notes.asciidoc
@@ -19,10 +19,13 @@
 // John D. Ament, Andy McCright
 
 [[release_notes_11]]
-== Release Notes for MicroProfile Rest CLient 1.1
+== Release Notes for MicroProfile Rest Client 1.1
 
 Changes since 1.0:
 
+- Asynchronous method support when Rest Client interfaces return `CompletionStage`.
+- New SPI interface, `RestClientBuilderListener` for intercepting new clients.
+- `@RegisterRestClient` is now considered a bean-defining annotation.
 - New `baseUri` method on `RestClientBuilder`.
 
 


### PR DESCRIPTION
Added async method support, `RestClientBuilderListener`, and `@RegisterRestClient` as a bean defining annotation to the 1.1 release notes.

Added `@since 1.1` to `executorService` method and `RestClientBuilderListener` interface.

This resolves issue #118.

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>