### PR TITLE
AsyncInvocationInterceptor needs removeContext() method

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/rest/client/ext/AsyncInvocationInterceptor.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/ext/AsyncInvocationInterceptor.java
@@ -36,6 +36,8 @@ package org.eclipse.microprofile.rest.client.ext;
  * Note that the order in which instances of the
  * <code>AsyncInvocationInterceptor</code> are invoked are determined by the
  * priority of the <code>AsyncInvocationInterceptorFactory</code> provider.
+ *
+ * @since 1.1
  */
 public interface AsyncInvocationInterceptor {
 
@@ -52,4 +54,14 @@ public interface AsyncInvocationInterceptor {
      * wait for the response) prior to sending the request.
      */
     void applyContext();
+
+    /**
+     * This method will be invoked by the MP Rest Client runtime on the "async"
+     * thread (i.e. the thread used to actually invoke the remote service and
+     * wait for the response) after all providers on the inbound response flow
+     * have been invoked.
+     *
+     * @since 1.2
+     */
+     void removeContext();
 }

--- a/api/src/main/java/org/eclipse/microprofile/rest/client/ext/AsyncInvocationInterceptorFactory.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/ext/AsyncInvocationInterceptorFactory.java
@@ -38,6 +38,7 @@ package org.eclipse.microprofile.rest.client.ext;
  * Implementations of this or the <code>AsyncInvocationInterceptor</code>
  * interface should not rely on the order of other providers, as this could
  * change between different implementations of the MP Rest Client.
+ * @since 1.1
  */
 public interface AsyncInvocationInterceptorFactory {
 
@@ -48,6 +49,8 @@ public interface AsyncInvocationInterceptorFactory {
      * <code>prepareContext</code> and <code>applyContext</code> methods of the
      * returned interceptor when performing an asynchronous method invocation.
      * Null return values will be ignored.
+     *
+     * @return Non-null instance of <code>AsyncInvocationInterceptor</code>
      */
     AsyncInvocationInterceptor newInterceptor();
 }

--- a/spec/src/main/asciidoc/async.asciidoc
+++ b/spec/src/main/asciidoc/async.asciidoc
@@ -54,6 +54,7 @@ This can be accomplished by registering an implementation of the AsyncInvocation
 MP Rest Client implementations must invoke the `newInterceptor` method of each registered factory provider prior to switching thread of execution on async method requests.
 That method will return an instance of `AsyncInvocationInterceptor` - the MP Rest Client implementation must then invoke the `prepareContext` method while still executing on the thread that invoked the async method.
 After swapping threads, but before invoking further providers or returning control back to the async method caller, the MP Rest Client implementation must invoke the `applyContext` method on the new async thread that will complete the request/response.
+The implementation must then invoke all inbound response providers (filters, interceptors, MessageBodyReaders, etc.) and then must invoke the `AsyncInvocationInterceptor`'s `removeContext` method.  This allows the provider to remove any contexts from the thread before returning control back to the user.
 
 The following example shows how the AsyncInvocationInterceptorFactory provider and associated AsyncInvocationInterceptor interface could be used to propagate a `ThreadLocal` value from the originating thread to async thread:
 [source, java]
@@ -75,6 +76,9 @@ public class MyInterceptor implements AsyncInvocationInterceptor {
     }
     public void applyContext() {
         SomeClass.setValueIntoThreadLocal(someValue);
+    }
+    public void removeContext() {
+        SomeClass.setValueIntoThreadLocal(null);
     }
 }
 

--- a/spec/src/main/asciidoc/release_notes.asciidoc
+++ b/spec/src/main/asciidoc/release_notes.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+// Copyright (c) 2016-2018 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.
@@ -17,6 +17,13 @@
 // limitations under the License.
 // Contributors:
 // John D. Ament, Andy McCright
+
+[[release_notes_12]]
+== Release Notes for MicroProfile Rest Client 1.2
+
+Changes since 1.1:
+
+- New `removeContext` method for `AsyncInvocationInterceptor` interface.
 
 [[release_notes_11]]
 == Release Notes for MicroProfile Rest Client 1.1

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TLAsyncInvocationInterceptor.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TLAsyncInvocationInterceptor.java
@@ -45,4 +45,10 @@ public class TLAsyncInvocationInterceptor implements AsyncInvocationInterceptor 
         }
         TLAsyncInvocationInterceptorFactory.setTlInt(tlValue);
     }
+
+    @Override
+    public void removeContext() {
+        factory.getData().put("removeThreadId", Thread.currentThread().getId());
+        TLAsyncInvocationInterceptorFactory.setTlInt(1);
+    }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TLClientResponseFilter.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TLClientResponseFilter.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.providers;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientResponseContext;
+import javax.ws.rs.client.ClientResponseFilter;
+import java.io.IOException;
+
+public class TLClientResponseFilter implements ClientResponseFilter{
+
+    private int threadLocalIntDuringResponse;
+
+    @Override
+    public void filter(ClientRequestContext reqCtx, ClientResponseContext resCtx) throws IOException {
+        threadLocalIntDuringResponse = TLAsyncInvocationInterceptorFactory.getTlInt();
+        resCtx.getHeaders().putSingle("Sent-URI", reqCtx.getUri().toString());
+    }
+
+    public int getThreadLocalIntDuringResponse() {
+        return threadLocalIntDuringResponse;
+    }
+}


### PR DESCRIPTION
Updates to API interface, spec doc, and TCK to add a `removeContext()` method to `AsyncInvocationInterceptor`.  This method should be invoked after all providers have been invoked on the response pipeline.  

This resolves issue #122. 

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>