### PR TITLE
Issue 121: RestClientBuilder SPI

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/rest/client/spi/RestClientListener.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/spi/RestClientListener.java
@@ -1,0 +1,45 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.rest.client.spi;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+
+/**
+ * Implementations of this interface will be notified when new Rest Client
+ * instances are being constructed.  This will allow implementations to register
+ * providers on the RestClientBuilder, and is intended for global providers.
+ *
+ * In order for the RestClientBuilder implementation to call implementations of
+ * this interface, the implementation must be specified such that
+ * <code>ServiceLoader</code> can find it - i.e. it must be specified in the <code>
+ * META-INF/services/org.eclipse.microprofile.rest.client.spi.RestClientListener
+ * </code> file in an archive on the current thread's context classloader's
+ * class path - or specified in the <code>module-info.java</code>.
+ *
+ * Note that the <code>onNewClient</code> method will be called when the
+ * RestClientBuilder's <code>build(Class&lt;?&gt; serviceInterface)</code> method is
+ * called.
+ *
+ * @since 1.2
+ */
+public interface RestClientListener {
+
+    void onNewClient(Class<?> serviceInterface, RestClientBuilder builder);
+}

--- a/spec/src/main/asciidoc/providers.asciidoc
+++ b/spec/src/main/asciidoc/providers.asciidoc
@@ -90,7 +90,7 @@ Any methods that read the response body as a stream must ensure that they reset 
 
 In addition to defining providers via the client definition, interfaces may use the `@RegisterProvider` annotation to define classes to be registered as providers in addition to providers registered via the `RestClientBuilder`
 
-Providers may also be registered by implementing the `RestClientBuilderListener` interface.  This interface is intended as an SPI to allow global provider registration.  The implementation of this interface must be specified in a `META-INF/services/org.eclipse.microprofile.rest.client.spi.RestClientBuilderListener` file, following the service loader pattern.
+Providers may also be registered by implementing the `RestClientBuilderListener` or `RestClientListener` interfaces.  These interfaces are intended as SPIs to allow global provider registration.  The implementation of these interface must be specified in a `META-INF/services/org.eclipse.microprofile.rest.client.spi.RestClientBuilderListener` or `META-INF/services/org.eclipse.microprofile.rest.client.spi.RestClientListener` file, respectively, following the `ServiceLoader` pattern.
 
 === Provider Priority
 

--- a/spec/src/main/asciidoc/release_notes.asciidoc
+++ b/spec/src/main/asciidoc/release_notes.asciidoc
@@ -23,6 +23,7 @@
 
 Changes since 1.1:
 
+- New SPI interface, `RestClientListener` interface for intercepting new client instances.
 - New `removeContext` method for `AsyncInvocationInterceptor` interface.
 
 [[release_notes_11]]
@@ -31,7 +32,7 @@ Changes since 1.1:
 Changes since 1.0:
 
 - Asynchronous method support when Rest Client interfaces return `CompletionStage`.
-- New SPI interface, `RestClientBuilderListener` for intercepting new clients.
+- New SPI interface, `RestClientBuilderListener` for intercepting new client builders.
 - `@RegisterRestClient` is now considered a bean-defining annotation.
 - New `baseUri` method on `RestClientBuilder`.
 

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/RestClientListenerTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/RestClientListenerTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck;
+
+import static org.testng.Assert.assertEquals;
+
+import java.net.URI;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.spi.RestClientListener;
+import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
+import org.eclipse.microprofile.rest.client.tck.providers.ReturnWith200RequestFilter;
+import org.eclipse.microprofile.rest.client.tck.providers.ReturnWith500RequestFilter;
+import org.eclipse.microprofile.rest.client.tck.spi.SimpleRestClientListenerImpl;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+/**
+ *
+ */
+public class RestClientListenerTest extends Arquillian {
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        StringAsset serviceFile = new StringAsset(SimpleRestClientListenerImpl.class.getName());
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class)
+            .addClasses(SimpleGetApi.class,
+                        SimpleRestClientListenerImpl.class,
+                        ReturnWith500RequestFilter.class)
+            .addAsManifestResource(serviceFile,"services/" + RestClientListener.class.getName());
+        return ShrinkWrap.create(WebArchive.class, RestClientListenerTest.class.getSimpleName()+".war")
+            .addAsLibrary(jar)
+            .addClasses(RestClientListenerTest.class, ReturnWith500RequestFilter.class);
+    }
+
+    /**
+     * This test checks that a RestClientListener loaded via the service loader
+     * is invoked.  The RestClientListener impl used will register a
+     * ClientRequestFilter that aborts with a 500 status code - it is registered
+     * with priority 1.  The test class registers another filter that will abort
+     * with a 200 status code, but at priority 2.  If the RestClientListener impl
+     * is correctly invoked, then the request will abort with the 500; if not,
+     * it will abort with the 200.  This test will also check that the correct
+     * serviceInterface class was passed to the RestClientListener impl.
+     *
+     * @throws Exception - indicates test failure
+     */
+    @Test
+    public void testRestClientListenerInvoked() throws Exception {
+        SimpleGetApi client = RestClientBuilder.newBuilder()
+            .register(ReturnWith200RequestFilter.class, 2)
+            .baseUri(new URI("http://localhost:8080/neverUsed"))
+            .build(SimpleGetApi.class);
+
+        assertEquals(client.executeGet().getStatus(), 500,
+            "The RestClientListener impl was not invoked");
+        assertEquals(SimpleRestClientListenerImpl.getServiceInterface(), SimpleGetApi.class,
+            "An incorrect serviceInterface class was passed to the RestClientListener impl");
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/spi/SimpleRestClientListenerImpl.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/spi/SimpleRestClientListenerImpl.java
@@ -1,0 +1,39 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.rest.client.tck.spi;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.spi.RestClientListener;
+import org.eclipse.microprofile.rest.client.tck.providers.ReturnWith500RequestFilter;
+
+public class SimpleRestClientListenerImpl implements RestClientListener {
+
+    private static Class<?> serviceInterface;
+
+    public static Class<?> getServiceInterface() {
+        return serviceInterface;
+    }
+
+    @Override
+    public void onNewClient(Class<?> serviceInterface, RestClientBuilder builder) {
+        SimpleRestClientListenerImpl.serviceInterface = serviceInterface;
+        builder.register(ReturnWith500RequestFilter.class, 1);
+    }
+}


### PR DESCRIPTION
This enables global registration of providers, etc. during the creation of rest client instances (as opposed to builders). It also passes in the rest client service interface allowing implementations to perform client-specific computations.

This resolves issue #121.

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>