### PR TITLE
Issue 121: Add `...invokedMethod` property to `ClientRequestContext`

### DIFF
--- a/spec/src/main/asciidoc/providers.asciidoc
+++ b/spec/src/main/asciidoc/providers.asciidoc
@@ -27,6 +27,8 @@ Filters of type `ClientResponseFilter` are invoked in order when a response is r
 
 Filters of type `ClientRequestFilter` are invoked in order when a request is made to a remote service.
 
+Both the `ClientRequestFilter` and `ClientResponseFilter` interfaces contains methods that pass an instance of `ClientRequestContext`.  The Rest Client implementation must provide a property via that `ClientRequestContext` called `org.eclipse.microprofile.rest.client.invokedMethod` - the value of this property should be the `java.lang.reflect.Method` object representing the Rest Client interface method currently being invoked.
+
 === MessageBodyReader
 
 The `MessageBodyReader` interface defined by JAX-RS allows the entity to be read from the API response after invocation.

--- a/spec/src/main/asciidoc/release_notes.asciidoc
+++ b/spec/src/main/asciidoc/release_notes.asciidoc
@@ -23,6 +23,7 @@
 
 Changes since 1.1:
 
+- `ClientRequestContext` should have a property named `org.eclipse.microprofile.rest.client.invokedMethod` containing the Rest Client `Method` currently being invoked.
 - New SPI interface, `RestClientListener` interface for intercepting new client instances.
 - New `removeContext` method for `AsyncInvocationInterceptor` interface.
 

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokedMethodTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokedMethodTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck;
+
+import static org.testng.Assert.assertEquals;
+
+import java.net.URI;
+
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.tck.interfaces.BaseClient;
+import org.eclipse.microprofile.rest.client.tck.interfaces.ChildClient;
+import org.eclipse.microprofile.rest.client.tck.providers.InvokedMethodRequestFilter;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+/**
+ * This tests the <code>org.eclipse.microprofile.rest.client.invokedMethod</code> property
+ * that implementations must provide in the `ClientRequestContext` of `ClientRequestFilter`s
+ * and `ClientResponseFilter`s.
+ */
+public class InvokedMethodTest extends Arquillian {
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, InvokedMethodTest.class.getSimpleName()+".war")
+            .addClasses(InvokedMethodTest.class,
+                        BaseClient.class,
+                        ChildClient.class,
+                        InvokedMethodRequestFilter.class);
+    }
+
+    /**
+     * This test checks that the Rest Client implementation provides the
+     * <i>methodInvoked</i> property to the <code>ClientRequestContext</code>
+     * in a <code>ClientRequestFilter</code>. The user's <code>ClientRequestFilter</code>
+     * should be able to read the return type, annotations, and parameters from
+     * the <code>Method</code> from that property.
+     *
+     * @throws Exception - indicates test failure
+     */
+    @Test
+    public void testRequestFilterReturnsMethodInvoked() throws Exception {
+        ChildClient client = RestClientBuilder.newBuilder()
+            .register(InvokedMethodRequestFilter.class)
+            .baseUri(new URI("http://localhost:8080/neverUsed"))
+            .build(ChildClient.class);
+
+        Response response = client.executeBasePost();
+        assertEquals(response.getStatus(), 200,
+            "An exception occurred in the ClientRequestFilter");
+        assertEquals(response.getHeaderString("ReturnType"), Response.class.getName());
+        assertEquals(response.getHeaderString("POST"), "POST");
+        assertEquals(response.getHeaderString("Path"), "/childOverride");
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/InvokedMethodRequestFilter.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/InvokedMethodRequestFilter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.providers;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+
+import javax.ws.rs.Path;
+import javax.ws.rs.POST;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.Response;
+
+
+public class InvokedMethodRequestFilter implements ClientRequestFilter {
+
+    @Override
+    public void filter(ClientRequestContext ctx) throws IOException {
+        try {
+            Method m = (Method) ctx.getProperty("org.eclipse.microprofile.rest.client.invokedMethod");
+
+            Path path = m.getAnnotation(Path.class);
+            ctx.abortWith(Response.ok("OK")
+                                  .header("ReturnType", m.getReturnType().getName())
+                                  .header("POST", m.getAnnotation(POST.class) == null ? "null" : "POST")
+                                  .header("Path", path == null ? "null" : path.value())
+                                  .build());
+        }
+        catch (Throwable t) {
+            t.printStackTrace();
+            ctx.abortWith(Response.serverError().build());
+        }
+    }
+}


### PR DESCRIPTION
This change requires MP Rest Client implementations to provide the
invoked `java.lang.reflect.Method` to `ClientRequestFilter`s and
`ClientResponseFilter`s as a property in `ClientRequestContext`.

This PR (in addition to #124) should resolve issue #121.

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>