### PR TITLE
Issue 53: Connect and read timeouts

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.net.URL;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ServiceLoader;
+import java.util.concurrent.TimeUnit;
 
 import javax.ws.rs.core.Configurable;
 import java.util.concurrent.ExecutorService;
@@ -101,6 +102,52 @@ public interface RestClientBuilder extends Configurable<RestClientBuilder> {
             throw new IllegalArgumentException(ex);
         }
     }
+
+    /**
+     * Set the connect timeout.
+     * <p>
+     * Like JAX-RS's <code>javax.ws.rs.client.ClientBuilder</code>'s
+     * <code>connectTimeout</code> method, specifying a timeout of 0 represents
+     * infinity, and negative values are not allowed.
+     * </p>
+     * <p>
+     * If the &quot;<em>fully.qualified.InterfaceName</em>/mp-rest/connectTimeout@quot;
+     * property is set via MicroProfile Config, that property's value will
+     * override, the value specified to this method.
+     * </p>
+     *
+     * @param timeout the maximum time to wait.
+     * @param unit the time unit of the timeout argument.
+     * @return the current builder with the connect timeout set.
+     * @throws IllegalArgumentException - if the value of timeout is negative.
+     * @since 1.2
+     */
+    RestClientBuilder connectTimeout(long timeout, TimeUnit unit);
+
+    /**
+     * Set the read timeout.
+     * <p>
+     * Like JAX-RS's <code>javax.ws.rs.client.ClientBuilder</code>'s
+     * <code>readTimeout</code> method, specifying a timeout of 0 represents
+     * infinity, and negative values are not allowed.
+     * </p>
+     * <p>
+     * Also like the JAX-RS Client API, if the read timeout is reached, the
+     * client interface method will throw a <code>javax.ws.rs.ProcessingException</code>.
+     * </p>
+     * <p>
+     * If the &quot;<em>fully.qualified.InterfaceName</em>/mp-rest/readTimeout@quot;
+     * property is set via MicroProfile Config, that property's value will
+     * override, the value specified to this method.
+     * </p>
+     *
+     * @param timeout the maximum time to wait.
+     * @param unit the time unit of the timeout argument.
+     * @return the current builder with the connect timeout set.
+     * @throws IllegalArgumentException - if the value of timeout is negative.
+     * @since 1.2
+     */
+    RestClientBuilder readTimeout(long timeout, TimeUnit unit);
 
     /**
      * Specifies the <code>ExecutorService</code> to use when invoking

--- a/api/src/test/java/org/eclipse/microprofile/rest/client/BuilderImpl1.java
+++ b/api/src/test/java/org/eclipse/microprofile/rest/client/BuilderImpl1.java
@@ -20,6 +20,7 @@ import javax.annotation.Priority;
 import java.net.URI;
 import java.net.URL;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 
 @Priority(1)
 public class BuilderImpl1 extends AbstractBuilder {
@@ -34,6 +35,16 @@ public class BuilderImpl1 extends AbstractBuilder {
     }
 
     public RestClientBuilder executorService(ExecutorService executor) {
+        throw new IllegalStateException("not implemented");
+    }
+
+    @Override
+    public RestClientBuilder connectTimeout(long timeout, TimeUnit unit) {
+        throw new IllegalStateException("not implemented");
+    }
+
+    @Override
+    public RestClientBuilder readTimeout(long timeout, TimeUnit unit) {
         throw new IllegalStateException("not implemented");
     }
 

--- a/api/src/test/java/org/eclipse/microprofile/rest/client/BuilderImpl2.java
+++ b/api/src/test/java/org/eclipse/microprofile/rest/client/BuilderImpl2.java
@@ -20,6 +20,7 @@ import javax.annotation.Priority;
 import java.net.URI;
 import java.net.URL;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 
 @Priority(2)
 public class BuilderImpl2 extends AbstractBuilder {
@@ -34,6 +35,16 @@ public class BuilderImpl2 extends AbstractBuilder {
     }
 
     public RestClientBuilder executorService(ExecutorService executor) {
+        throw new IllegalStateException("not implemented");
+    }
+
+    @Override
+    public RestClientBuilder connectTimeout(long timeout, TimeUnit unit) {
+        throw new IllegalStateException("not implemented");
+    }
+
+    @Override
+    public RestClientBuilder readTimeout(long timeout, TimeUnit unit) {
         throw new IllegalStateException("not implemented");
     }
 

--- a/spec/src/main/asciidoc/cdi.asciidoc
+++ b/spec/src/main/asciidoc/cdi.asciidoc
@@ -79,6 +79,8 @@ The values of the following properties will be provided via MicroProfile Config:
 - `com.mycompany.remoteServices.MyServiceClient/mp-rest/scope`: The fully qualified classname to a CDI scope to use for injection, defaults to `javax.enterprise.context.Dependent` as mentioned above.
 - `com.mycompany.remoteServices.MyServiceClient/mp-rest/providers`: A comma separated list of fully-qualified provider classnames to include in the client, the equivalent of the `register` method or the `@RegisterProvider` annotation.
 - `com.mycompany.remoteServices.MyServiceClient/mp-rest/providers/com.mycompany.MyProvider/priority` will override the priority of the provider for this interface.
+- `com.mycompany.remoteServices.MyServiceClient/mp-rest/connectTimeout`: Timeout specified in milliseconds to wait to connect to the remote endpoint.
+- `com.mycompany.remoteServices.MyServiceClient/mp-rest/readTimeout`: Timeout specified in milliseconds to wait for a response from the remote endpoint.
 
 Implementations may support other custom properties registered in similar fashions or other ways.
 

--- a/spec/src/main/asciidoc/release_notes.asciidoc
+++ b/spec/src/main/asciidoc/release_notes.asciidoc
@@ -23,6 +23,7 @@
 
 Changes since 1.1:
 
+- New `connectTimeout` and `readTimeout` methods on `RestClientBuilder` - and corresponding MP Config properties.
 - `ClientRequestContext` should have a property named `org.eclipse.microprofile.rest.client.invokedMethod` containing the Rest Client `Method` currently being invoked.
 - New SPI interface, `RestClientListener` interface for intercepting new client instances.
 - New `removeContext` method for `AsyncInvocationInterceptor` interface.

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/TimeoutTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/TimeoutTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck;
+
+import static org.testng.Assert.assertTrue;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+public class TimeoutTest extends TimeoutTestBase {
+
+    private static final int UNUSED_PORT =
+        AccessController.doPrivileged((PrivilegedAction<Integer>) () -> {
+            return Integer.getInteger(
+                "org.eclipse.microprofile.rest.client.tck.unusedPort", 23);
+        });
+
+    @Deployment
+    public static Archive<?> createDeployment() {
+        String simpleName = TimeoutTest.class.getSimpleName();
+        return ShrinkWrap.create(WebArchive.class, simpleName + ".war")
+                         .addClasses(WiremockArquillianTest.class,
+                                     TimeoutTestBase.class,
+                                     SimpleGetApi.class);
+    }
+
+    @Override
+    protected void checkTimeElapsed(long min, long max, long elapsed) {
+        assertTrue(elapsed >= 5);
+        // allow an extra 10 seconds cushion for slower test machines
+        assertTrue(elapsed < 15);
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/TimeoutTestBase.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/TimeoutTestBase.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.testng.Assert.fail;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.concurrent.TimeUnit;
+import java.net.URI;
+
+import javax.ws.rs.ProcessingException;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
+import org.testng.annotations.Test;
+
+
+
+
+
+public abstract class TimeoutTestBase extends WiremockArquillianTest {
+
+    private static final String UNUSED_URL =
+        AccessController.doPrivileged((PrivilegedAction<String>) () -> {
+            return System.getProperty(
+                "org.eclipse.microprofile.rest.client.tck.unusedURL",
+                "http://microprofile.io:1234/null");
+        });
+
+    @Test(expectedExceptions={ProcessingException.class})
+    public void testConnectTimeout() throws Exception {
+
+        SimpleGetApi simpleGetApi = RestClientBuilder.newBuilder()
+            .baseUri(URI.create(UNUSED_URL))
+            .connectTimeout(5, TimeUnit.SECONDS)
+            .build(SimpleGetApi.class);
+        long startTime = System.nanoTime();
+        try {
+            simpleGetApi.executeGet();
+            fail("A ProcessingException should have been thrown to indicate a timeout");
+        }
+        finally {
+            long elapsedTime = System.nanoTime() - startTime;
+            long elapsedSecs = TimeUnit.SECONDS.convert(elapsedTime, TimeUnit.NANOSECONDS);
+            checkTimeElapsed(5, 15, elapsedSecs);
+        }
+    }
+
+    @Test(expectedExceptions={ProcessingException.class})
+    public void testReadTimeout() throws Exception {
+
+        stubFor(get(urlEqualTo("/")).willReturn(aResponse()
+                                        .withStatus(200)
+                                        .withFixedDelay(30000)));
+        SimpleGetApi simpleGetApi = RestClientBuilder.newBuilder()
+            .baseUri(getServerURI())
+            .readTimeout(5, TimeUnit.SECONDS)
+            .build(SimpleGetApi.class);
+
+        long startTime = System.nanoTime();
+        try {
+            simpleGetApi.executeGet();
+            fail("A ProcessingException should have been thrown due to a read timeout");
+        }
+        finally {
+            long elapsedTime = System.nanoTime() - startTime;
+            long elapsedSecs = TimeUnit.SECONDS.convert(elapsedTime, TimeUnit.NANOSECONDS);
+            checkTimeElapsed(5, 15, elapsedSecs);
+        }
+    }
+
+    protected abstract void checkTimeElapsed(long min, long max, long elapsed);
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/TimeoutViaMPConfigTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/TimeoutViaMPConfigTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck;
+
+import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+import static org.testng.Assert.assertTrue;
+
+public class TimeoutViaMPConfigTest extends TimeoutTestBase {
+
+    @Deployment
+    public static Archive<?> createDeployment() {
+        String clientName = SimpleGetApi.class.getName();
+        String timeoutProps = clientName + "/mp-rest/connectTimeout=7000" +
+                              System.lineSeparator() +
+                              clientName + "/mp-rest/readTimeout=7000";
+        StringAsset mpConfig = new StringAsset(timeoutProps);
+        return ShrinkWrap.create(WebArchive.class, TimeoutViaMPConfigTest.class.getSimpleName()+".war")
+            .addAsWebInfResource(mpConfig, "classes/META-INF/microprofile-config.properties")
+            .addClasses(SimpleGetApi.class,
+                        TimeoutTest.class,
+                        TimeoutTestBase.class,
+                        WiremockArquillianTest.class);
+    }
+
+    @Override
+    protected void checkTimeElapsed(long min, long max, long elapsed) {
+        assertTrue(elapsed >= 7);
+        // allow an extra 10 seconds cushion for slower test machines
+        assertTrue(elapsed < 17);
+    }
+}


### PR DESCRIPTION
Spec, API, and TCK tests for setting connect and read timeouts. These can be set using the API in RestClientBuilder or via MP Config.

This resolves issue #53.

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>