### PR TITLE
Various tweaks for async and RestClientListener TCK test

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/RestClientListenerTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/RestClientListenerTest.java
@@ -68,6 +68,7 @@ public class RestClientListenerTest extends Arquillian {
     public void testRestClientListenerInvoked() throws Exception {
         SimpleGetApi client = RestClientBuilder.newBuilder()
             .register(ReturnWith200RequestFilter.class, 2)
+            .property("microprofile.rest.client.disable.default.mapper",true)
             .baseUri(new URI("http://localhost:8080/neverUsed"))
             .build(SimpleGetApi.class);
 

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/asynctests/AsyncMethodTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/asynctests/AsyncMethodTest.java
@@ -220,7 +220,7 @@ public class AsyncMethodTest extends WiremockArquillianTest{
         assertEquals(response.getStatus(), 200);
         String sentUri = response.getHeaderString("Sent-URI");
         assertTrue(sentUri.endsWith("/" + threadLocalInt));
-        assertEquals((long) TLAsyncInvocationInterceptorFactory.getTlInt(), 1L);
+        assertEquals((long) TLAsyncInvocationInterceptorFactory.getTlInt(), 808L);
         assertEquals((long) responseFilter.getThreadLocalIntDuringResponse(), (long) threadLocalInt);
 
         String body = response.readEntity(String.class);
@@ -232,6 +232,8 @@ public class AsyncMethodTest extends WiremockArquillianTest{
         assertEquals(data.get("preThreadId"), mainThreadId);
         assertNotEquals(data.get("postThreadId"), mainThreadId);
         assertEquals(data.get("removeThreadId"), data.get("postThreadId"));
+        assertEquals(data.get("AsyncThreadLocalPre"), 808);
+        assertEquals(data.get("AsyncThreadLocalPost"), 0);
 
         verify(1, getRequestedFor(urlEqualTo("/" + threadLocalInt)));
     }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TLAsyncInvocationInterceptor.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TLAsyncInvocationInterceptor.java
@@ -49,6 +49,8 @@ public class TLAsyncInvocationInterceptor implements AsyncInvocationInterceptor 
     @Override
     public void removeContext() {
         factory.getData().put("removeThreadId", Thread.currentThread().getId());
-        TLAsyncInvocationInterceptorFactory.setTlInt(1);
+        factory.getData().put("AsyncThreadLocalPre", TLAsyncInvocationInterceptorFactory.getTlInt());
+        TLAsyncInvocationInterceptorFactory.setTlInt(0);
+        factory.getData().put("AsyncThreadLocalPost", TLAsyncInvocationInterceptorFactory.getTlInt());
     }
 }


### PR DESCRIPTION
During testing with an initial implementation, I discovered a few bugs in the TCK:

- In the `RestClientListenerTest`, the default response exception mapper was throwing an exception rather than allowing the test to check for a specific 500 response.  The change is to disable the default mapper.
- The new `removeContext` method on `AsyncInvocationInterceptor` was not tested correctly - the test assumed it was invoked on the initial thread, not the async thread.  The change is ensure that the removeContext method is run on the async thread by recording it's invocation in a map that is not tied to a specific thread.

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>