### PR TITLE
Issue 90: Allow URI to be set in `@RegisterRestClient` annotation

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/rest/client/inject/RegisterRestClient.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/inject/RegisterRestClient.java
@@ -40,4 +40,5 @@ import javax.enterprise.inject.Stereotype;
 @Stereotype
 @Dependent
 public @interface RegisterRestClient {
+    String baseUri() default "";
 }

--- a/spec/src/main/asciidoc/cdi.asciidoc
+++ b/spec/src/main/asciidoc/cdi.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 Contributors to the Eclipse Foundation
+// Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ Rest Client interfaces may be injected as CDI beans.  The runtime must create a 
 ----
 package com.mycompany.remoteServices;
 
-@RegisterRestClient
+@RegisterRestClient(baseUri="http://someHost/someContextRoot")
 public interface MyServiceClient {
     @GET
     @Path("/greet")
@@ -59,7 +59,7 @@ Interfaces are assumed to have a scope of `@Dependent` unless there is another s
 
 === Support for MicroProfile Config
 
-For CDI defined interfaces, it is possible to use MicroProfile Config properties to define additional behaviors of the rest interface.  Assuming this interface:
+For CDI defined interfaces, it is possible to use MicroProfile Config properties to define additional behaviors or override values specified in the `@RegisterRestClient` annotation of the rest interface.  Assuming this interface:
 
 [source, java]
 ----
@@ -75,7 +75,7 @@ public interface MyServiceClient {
 The values of the following properties will be provided via MicroProfile Config:
 
 - `com.mycompany.remoteServices.MyServiceClient/mp-rest/url`: The base URL to use for this service, the equivalent of the `baseUrl` method.  This property (or */mp-rest/uri) is considered required, however implementations may have other ways to define these URLs/URIs.
-- `com.mycompany.remoteServices.MyServiceClient/mp-rest/uri`: The base URI to use for this service, the equivalent of the `baseUri` method.  This property (or */mp-rest/url) is considered required, however implementations may have other ways to define these URLs/URIs.
+- `com.mycompany.remoteServices.MyServiceClient/mp-rest/uri`: The base URI to use for this service, the equivalent of the `baseUri` method.  This property (or */mp-rest/url) is considered required, however implementations may have other ways to define these URLs/URIs. This property will override any `baseUri` value specified in the `@RegisterRestClient` annotation.
 - `com.mycompany.remoteServices.MyServiceClient/mp-rest/scope`: The fully qualified classname to a CDI scope to use for injection, defaults to `javax.enterprise.context.Dependent` as mentioned above.
 - `com.mycompany.remoteServices.MyServiceClient/mp-rest/providers`: A comma separated list of fully-qualified provider classnames to include in the client, the equivalent of the `register` method or the `@RegisterProvider` annotation.
 - `com.mycompany.remoteServices.MyServiceClient/mp-rest/providers/com.mycompany.MyProvider/priority` will override the priority of the provider for this interface.

--- a/spec/src/main/asciidoc/release_notes.asciidoc
+++ b/spec/src/main/asciidoc/release_notes.asciidoc
@@ -23,6 +23,7 @@
 
 Changes since 1.1:
 
+- New `baseUri` property added to `@RegisterRestClient` annotation.
 - New `connectTimeout` and `readTimeout` methods on `RestClientBuilder` - and corresponding MP Config properties.
 - `ClientRequestContext` should have a property named `org.eclipse.microprofile.rest.client.invokedMethod` containing the Rest Client `Method` currently being invoked.
 - New SPI interface, `RestClientListener` interface for intercepting new client instances.

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/ClientWithURI.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/ClientWithURI.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.tck.providers.ReturnWithURLRequestFilter;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/hello")
+@RegisterProvider(ReturnWithURLRequestFilter.class)
+@RegisterRestClient(baseUri="http://localhost:5017/myBaseUri")
+public interface ClientWithURI {
+    @GET
+    String get();
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/ClientWithURI2.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/ClientWithURI2.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.tck.providers.ReturnWithURLRequestFilter;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/hi")
+@RegisterProvider(ReturnWithURLRequestFilter.class)
+@RegisterRestClient(baseUri="http://localhost:5017/myBaseUri")
+public interface ClientWithURI2 {
+    @GET
+    String get();
+}


### PR DESCRIPTION
This issue resolves issue #90 though there may be other attributes we could add to the `@RegisterRestClient` annotations (one suggestion was providers but they can already be declared on the interface via `@RegisterProvider` annotations.  

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>