### PR TITLE
Minor tweaks to TCK

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/RestClientListenerTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/RestClientListenerTest.java
@@ -45,11 +45,12 @@ public class RestClientListenerTest extends Arquillian {
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class)
             .addClasses(SimpleGetApi.class,
                         SimpleRestClientListenerImpl.class,
+                        ReturnWith200RequestFilter.class,
                         ReturnWith500RequestFilter.class)
             .addAsManifestResource(serviceFile,"services/" + RestClientListener.class.getName());
         return ShrinkWrap.create(WebArchive.class, RestClientListenerTest.class.getSimpleName()+".war")
             .addAsLibrary(jar)
-            .addClasses(RestClientListenerTest.class, ReturnWith500RequestFilter.class);
+            .addClasses(RestClientListenerTest.class);
     }
 
     /**
@@ -68,7 +69,7 @@ public class RestClientListenerTest extends Arquillian {
     public void testRestClientListenerInvoked() throws Exception {
         SimpleGetApi client = RestClientBuilder.newBuilder()
             .register(ReturnWith200RequestFilter.class, 2)
-            .property("microprofile.rest.client.disable.default.mapper",true)
+            .property("microprofile.rest.client.disable.default.mapper", true)
             .baseUri(new URI("http://localhost:8080/neverUsed"))
             .build(SimpleGetApi.class);
 

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/CDIURIvsURLConfigTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/CDIURIvsURLConfigTest.java
@@ -108,11 +108,11 @@ public class CDIURIvsURLConfigTest extends WiremockArquillianTest{
 
     @Test
     public void testBaseUriInRegisterRestClientAnnotation() throws Exception {
-        assertEquals(clientWithURI.get(), "http://localhost:5017/myBaseUri/hello");
+        assertEquals(clientWithURI.get(), "GET http://localhost:5017/myBaseUri/hello");
     }
 
     @Test
     public void testMPConfigURIOverridesBaseUriInRegisterRestClientAnnotation() throws Exception {
-        assertEquals(clientWithURI2.get(), "http://localhost:9876/someOtherBaseUri/hi");
+        assertEquals(clientWithURI2.get(), "GET http://localhost:9876/someOtherBaseUri/hi");
     }
 }


### PR DESCRIPTION
Just a few tweaks to some TCK tests.

1. For `RestClientListenerTest`, ensure that we package all of the filters in the right place.
2. For `CDIURIvsURLConfigTest`, the filter returns the HTTP method ("GET") in addition to the URI used, so we need to check for that as well in the assertion.

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>