### PR TITLE
Issue 114: Clarifying and testing built-in JSON-B provider

### DIFF
--- a/spec/src/main/asciidoc/providers.asciidoc
+++ b/spec/src/main/asciidoc/providers.asciidoc
@@ -108,15 +108,17 @@ If the type of provider registered is a `Feature`, then the priority set by that
 
 Implementations may provide any number of providers registered automatically, but the following providers must be registered by the runtime.
 
-=== JSON-P Provider
+=== JSON-P and JSON-B Providers
+
+Implementations of the MicroProfile Rest Client should behave similar to JAX-RS implementations with regard to built-in JSON-P and JSON-B providers. Implementations must provide a built-in JSON-P entity provider. If the implementation supports JSON-B, then it must also provide a built-in JSON-B entity provider. Note that the JSON-B provider should take precedence over the JSON-P provider if both exist.
 
 When an interface is registered that contains:
 
 - `@Produces("*/json")` or
 - `@Consumes("*/json")` or
-- a method that declares input or output of type `javax.json.JsonValue` or any subclass therein
+- a method that declares input or output of type `javax.json.JsonValue` or any subclass therein (JSON-P only)
 
-Then a JSON-P `MessageBodyReader` and `MessageBodyWriter` will be registered automatically by the implementation.  This is in alignment with the JAX-RS 2.0 specification.  The provider registered will have a priority of `Integer.MAX_VALUE`, allowing a user to register a custom provider to be used instead.
+Then a JSON-B or JSON-P `MessageBodyReader` and `MessageBodyWriter` will be registered automatically by the implementation.  This is in alignment with the JAX-RS 2.1 specification.  The provider registered will have a priority of `Integer.MAX_VALUE`, allowing a user to register a custom provider to be used instead.
 
 === Default Message Body Readers and Writers
 

--- a/spec/src/main/asciidoc/release_notes.asciidoc
+++ b/spec/src/main/asciidoc/release_notes.asciidoc
@@ -23,6 +23,7 @@
 
 Changes since 1.1:
 
+- Clarification on built-in JSON-B/JSON-P entity providers.
 - New `baseUri` property added to `@RegisterRestClient` annotation.
 - New `connectTimeout` and `readTimeout` methods on `RestClientBuilder` - and corresponding MP Config properties.
 - `ClientRequestContext` should have a property named `org.eclipse.microprofile.rest.client.invokedMethod` containing the Rest Client `Method` currently being invoked.

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -66,6 +66,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>javax.json.bind</groupId>
+            <artifactId>javax.json.bind-api</artifactId>
+            <version>1.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>compile</scope>

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeWithJsonBProviderTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeWithJsonBProviderTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2018 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.reset;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.testng.Assert.assertEquals;
+
+import java.text.SimpleDateFormat;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.eclipse.microprofile.rest.client.tck.interfaces.JsonBClient;
+import org.eclipse.microprofile.rest.client.tck.interfaces.MyJsonBObject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.SkipException;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+
+public class InvokeWithJsonBProviderTest extends WiremockArquillianTest{
+
+    private static final String CDI = "cdi";
+    private static final String BUILT = "built";
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        StringAsset mpConfig = new StringAsset(JsonBClient.class.getName() + "/mp-rest/uri=" + getStringURL());
+        return ShrinkWrap.create(WebArchive.class, InvokeWithJsonBProviderTest.class.getSimpleName()+".war")
+            .addClasses(JsonBClient.class, WiremockArquillianTest.class, MyJsonBObject.class, InvokeWithJsonBProviderTest.class)
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addAsWebInfResource(mpConfig, "classes/META-INF/microprofile-config.properties");
+    }
+
+    private static void assumeJsonbApiExists() throws SkipException {
+        try {
+            Class.forName("javax.json.bind.annotation.JsonbProperty");
+        }
+        catch (Throwable t) {
+            throw new SkipException("Skipping since JSON-B APIs were not found.");
+        }
+    }
+
+    @RestClient
+    @Inject
+    private JsonBClient cdiJsonBClient;
+
+    private JsonBClient builtJsonBClient;
+
+    @BeforeTest
+    public void setupClient() throws Exception{
+        builtJsonBClient = RestClientBuilder.newBuilder()
+            .baseUri(getServerURI())
+            .build(JsonBClient.class);
+    }
+
+    @Test
+    public void testGetExecutesForBothClients() throws Exception {
+        assumeJsonbApiExists();
+        testGet(builtJsonBClient, BUILT);
+        testGet(cdiJsonBClient, CDI);
+    }
+
+
+    private void testGet(JsonBClient client, String clientType) throws Exception {
+        reset();
+        stubFor(get(urlEqualTo("/myObject"))
+            .willReturn(aResponse()
+                .withHeader("Content-Type", "application/json")
+                .withBody("{" +
+                             "\"objectName\": \"myObject\"};" +
+                             "\"quantity\": 17;" +
+                             "\"date\": \"2018-12-04\";" +
+                          "}")
+                    ));
+
+        MyJsonBObject obj = client.get("myObject");
+        assertEquals(obj.getName(), "myObject");
+        assertEquals(obj.getQty(), 17);
+        assertEquals(obj.getIgnoredField(), "CTOR");
+        assertEquals(obj.getDate(), new SimpleDateFormat("yyyy.MM.dd").parse("2018-12-04"));
+
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/JsonBClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/JsonBClient.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+
+@RegisterRestClient
+public interface JsonBClient {
+
+    @Path("/{objectName}")
+    @GET
+    @Produces("application/json")
+    MyJsonBObject get(@PathParam("objectName") String objectName);
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/MyJsonBObject.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/MyJsonBObject.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+import java.util.Date;
+import javax.json.bind.annotation.JsonbDateFormat;
+import javax.json.bind.annotation.JsonbProperty;
+import javax.json.bind.annotation.JsonbTransient;
+
+public class MyJsonBObject {
+
+    @JsonbProperty("objectName")
+    private String name;
+
+    private int qty;
+
+    @JsonbTransient
+    private String ignoredField;
+
+    @JsonbDateFormat("yyyy-MM-dd")
+    private Date date;
+
+    public MyJsonBObject() {
+        ignoredField = "CTOR";
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @JsonbProperty("quantity")
+    public int getQty() {
+        return qty;
+    }
+
+    @JsonbProperty("quantity")
+    public void setQty(int qty) {
+        this.qty = qty;
+    }
+
+    public String getIgnoredField() {
+        return ignoredField;
+    }
+
+    public Date getDate() {
+        return date;
+    }
+}


### PR DESCRIPTION
Clarifies that JSON-P entity provider is required, but JSON-B provider should be used if the product contains the JSON-B APIs.  This is consistent with the JAX-RS 2.1 spec.  

The TCK test will be skipped if it cannot load a JSON-B API class - otherwise it will test that JSON-B processing takes place.

This should resolve issue #114.


Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>