### PR TITLE
Issues #5 and #107: Clarify integration with CDI and FT

### DIFF
--- a/spec/src/main/asciidoc/cdi.asciidoc
+++ b/spec/src/main/asciidoc/cdi.asciidoc
@@ -57,6 +57,7 @@ The qualifier is used to differentiate use cases of the interface that are manag
 
 Interfaces are assumed to have a scope of `@Dependent` unless there is another scope defined on the interface.  Implementations are expected to support all of the built in scopes for a bean.  Support for custom registered scopes should work, but is not guaranteed.
 
+[[mpconfig]]
 === Support for MicroProfile Config
 
 For CDI defined interfaces, it is possible to use MicroProfile Config properties to define additional behaviors or override values specified in the `@RegisterRestClient` annotation of the rest interface.  Assuming this interface:

--- a/spec/src/main/asciidoc/integration.asciidoc
+++ b/spec/src/main/asciidoc/integration.asciidoc
@@ -1,0 +1,50 @@
+//
+// Copyright (c) 2018 Contributors to the Eclipse Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+[[integration]]
+== Integration with other MicroProfile technologies
+
+The MicroProfile Rest Client can be used as a standalone technology. That means that an implementation could work without CDI, MicroProfile Config, etc.
+This section documents how the MicroProfile Rest Client should interact when it is executed in an environment that provides other MicroProfile technologies.
+
+=== CDI
+
+Integration with CDI is already built-in to the Rest Client specification, and is documented in the <<cdi.asciidoc#restcdi>> section.
+
+If CDI is available, the MP Rest Client implementation must ensure that CDI business method interceptors are invoked when the appropriate interceptor binding is applied to the client interface or method.
+
+=== MicroProfile Config
+
+MP Rest Client uses MP Config in order to declaratively configure the client behavior. The remote URI, client providers and priority,
+connect and read timeouts, etc. can all be configured using MP Config. See <<cdi.asciidoc#mpconfig>> for more details.
+
+=== MicroProfile Fault Tolerance
+
+MP Rest Client implementations must ensure that MP Fault Tolerance annotations on client interfaces are honored. In general, these annotations are treated as
+CDI interceptor bindings.
+
+MP Rest Client should ensure that the behavior of most Fault Tolerance annotations should follow the behavior outlined in the MP Fault Tolerance specification.
+This includes the `@Asynchronous`, `@Bulkhead`, `@CircuitBreaker`, `@Fallback` and `@Retry` annotations.
+
+The `@Timeout` annotation presents a problem since some parts of the MP Rest Client request are non-blocking and non-interruptible. Implementations should override
+the default connect and read timeouts and use the timeout value specified in the `@Timeout` annotation instead. This will ensure that the actual time spent in
+blocking/non-interruptible operations should be less than or equal to the time specified in the annotation, allowing the MP Fault Tolerance implementation to
+interrupt the request and the throw the appropriate `TimeoutException`.
+
+=== Other MicroProfile Technologies
+
+Client requests can be automatically traced when using MP OpenTracing.  Likewise, requests can be measured using MP Metrics.
+Configuration and usage of these technologies should be defined in their respective specification documents.

--- a/spec/src/main/asciidoc/microprofile-rest-client.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-rest-client.asciidoc
@@ -48,4 +48,6 @@ include::cdi.asciidoc[]
 
 include::async.asciidoc[]
 
+include::integration.asciidoc[]
+
 include::release_notes.asciidoc[]

--- a/spec/src/main/asciidoc/release_notes.asciidoc
+++ b/spec/src/main/asciidoc/release_notes.asciidoc
@@ -23,6 +23,7 @@
 
 Changes since 1.1:
 
+- New section documenting the <<integration.asciidoc#integration>>.
 - Clarification on built-in JSON-B/JSON-P entity providers.
 - New `baseUri` property added to `@RegisterRestClient` annotation.
 - New `connectTimeout` and `readTimeout` methods on `RestClientBuilder` - and corresponding MP Config properties.

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/CDIInterceptorTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/CDIInterceptorTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.cditests;
+
+import static org.testng.Assert.assertEquals;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.eclipse.microprofile.rest.client.tck.interfaces.ClientWithURIAndInterceptor;
+import org.eclipse.microprofile.rest.client.tck.interfaces.Loggable;
+import org.eclipse.microprofile.rest.client.tck.interfaces.LoggableInterceptor;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+/**
+ * Verifies that CDI interceptors bound to client interface methods are invoked.
+ */
+public class CDIInterceptorTest extends Arquillian {
+
+    @Inject
+    @RestClient
+    private ClientWithURIAndInterceptor client;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        String simpleName = CDIInterceptorTest.class.getSimpleName();
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, simpleName + ".jar")
+            .addClasses(ClientWithURIAndInterceptor.class,
+                        Loggable.class,
+                        LoggableInterceptor.class)
+            .addAsManifestResource(new StringAsset(
+                "<beans xmlns=\"http://java.sun.com/xml/ns/javaee\"" +
+                "       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" +
+                "       xsi:schemaLocation=\"" +
+                "          http://java.sun.com/xml/ns/javaee" +
+                "          http://java.sun.com/xml/ns/javaee/beans_1_0.xsd\">" +
+                "       <interceptors>" +
+                "           <class>org.eclipse.microprofile.rest.client.tck.interfaces.LoggableInterceptor</class>" +
+                "       </interceptors>" +
+                "</beans>"),
+                "beans.xml");
+        return ShrinkWrap.create(WebArchive.class, simpleName + ".war")
+            .addAsLibrary(jar)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    public void testInterceptorInvoked() throws Exception {
+        LoggableInterceptor.setInvocationMessage("");
+        String expectedResponse = "GET http://localhost:5017/myBaseUri/hello";
+        assertEquals(client.get(), expectedResponse);
+
+        assertEquals(LoggableInterceptor.getInvocationMessage(),
+            ClientWithURIAndInterceptor.class.getName() + ".get " + expectedResponse);
+    }
+
+    @Test
+    public void testInterceptorNotInvokedWhenNoAnnotationApplied() throws Exception {
+        LoggableInterceptor.setInvocationMessage("");
+        String expectedResponse = "GET http://localhost:5017/myBaseUri/hello";
+        assertEquals(client.getNoInterceptor(), expectedResponse);
+
+        assertEquals(LoggableInterceptor.getInvocationMessage(), "");
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/ClientWithURIAndInterceptor.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/ClientWithURIAndInterceptor.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.tck.providers.ReturnWithURLRequestFilter;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/hello")
+@RegisterProvider(ReturnWithURLRequestFilter.class)
+@RegisterRestClient(baseUri="http://localhost:5017/myBaseUri")
+public interface ClientWithURIAndInterceptor {
+    @GET
+    @Loggable
+    String get();
+
+    @GET
+    String getNoInterceptor();
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/Loggable.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/Loggable.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Target;
+import java.lang.annotation.Retention;
+
+import javax.interceptor.InterceptorBinding;
+
+@InterceptorBinding
+@Target({METHOD, TYPE})
+@Retention(RUNTIME)
+public @interface Loggable {
+    String value() default "";
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/LoggableInterceptor.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/LoggableInterceptor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+import java.lang.reflect.Method;
+
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+@Loggable @Interceptor
+public class LoggableInterceptor {
+
+    private static String invocationMessage;
+
+    public static String getInvocationMessage() {
+        return invocationMessage;
+    }
+
+    public static void setInvocationMessage(String msg) {
+        invocationMessage = msg;
+    }
+
+    @AroundInvoke
+    public Object logInvocation(InvocationContext ctx) throws Exception {
+        Method m = ctx.getMethod();
+        invocationMessage = m.getDeclaringClass().getName() + "." + m.getName();
+        System.out.println("Invoking " + invocationMessage);
+        try {
+            Object returnVal = ctx.proceed();
+            invocationMessage += " " + returnVal;
+            return returnVal;
+        }
+        finally {
+            System.out.println("Invoked " + invocationMessage);
+        }
+    }
+}


### PR DESCRIPTION
Includes new "Integration" section in the spec document and new TCK test cases for CDI interceptor support.

This should resolve issues #5 and #107.

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>