### PR TITLE
[116] New `@ClientHeaderParam` annotation and TCK tests

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/rest/client/annotation/ClientHeaderParam.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/annotation/ClientHeaderParam.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Used to specify an HTTP parameter that should be sent with the outbound request.
+ * When this annotation is placed at the interface level of a REST client interface, the specified header will be sent on each request for all
+ * methods in the interface.
+ * When this annotation is placed on a method, the header will be sent only for that method. If the same HTTP header is specified in an annotation
+ * for both the type and the method, only the header value specified in the annotation on the method will be sent.
+ * <p>
+ * The value of the header to send can be specified explicitly by using the <code>value</code> attribute.
+ * The value can also be computed via a default method on the client interface that returns a String value.  This method must be specified in the
+ * <code>value</code> attribute but wrapped in curly-braces.
+ * The default method's signature must either contain no arguments or a single <code>String</code> argument. The String argument is the name of the
+ * header.
+ * <p>
+ * Here is an example using both approaches:
+ * <pre>
+ * public interface MyClient {
+ *
+ *    static AtomicInteger counter = new AtomicInteger(1);
+ *
+ *    default String determineHeaderValue(String headerName) {
+ *        if ("SomeHeader".equals(headerName)) {
+ *            return "InvokedCount " + counter.getAndIncrement();
+ *        }
+ *        throw new UnsupportedOperationException("unknown header name");
+ *    }
+ *
+ *    {@literal @}ClientHeaderParam(name="SomeHeader", value="ExplicitlyDefinedValue")
+ *    {@literal @}GET
+ *    Response useExplicitHeaderValue();
+ *
+ *    {@literal @}ClientHeaderParam(name="SomeHeader", value="{determineHeaderValue}")
+ *    {@literal @}DELETE
+ *    Response useComputedHeaderValue();
+ * }
+ * </pre>
+ * The implementation should fail to deploy a client interface if the annotation contains a <code>@ClientHeaderParam</code> annotation with a
+ * <code>value</code> attribute that references a method that does not exist, or contains an invalid signature.
+ * <p>
+ * The <code>required</code> attribute will determine what action the implementation should take if the method specified in the <code>value</code>
+ * attribute throws an exception. If the attribute is true (default), then the implementation will abort the request and will throw the exception
+ * back to the caller. If the <code>required</code> attribute is set to false, then the implementation will not send this header if the method throws
+ * an exception.
+ * <p>
+ * Note that if an interface method contains an argument annotated with <code>@HeaderParam</code>, that argument will take priority over anything
+ * specified in a ClientHeaderParam annotation.
+ *
+ * @since 1.2
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Repeatable(ClientHeaderParams.class)
+public @interface ClientHeaderParam {
+    /**
+     * @return the name of the HTTP header.
+     */
+    String name();
+
+    /**
+     * @return the value of the HTTP header - or the method to invoke to get the value (surrounded by curly braces).
+     */
+    String value();
+
+    /**
+     * @return whether to abort the request if the method to compute the header value throws an exception (true; default) or just skip this header
+     * (false)
+     */
+    boolean required() default true;
+}

--- a/api/src/main/java/org/eclipse/microprofile/rest/client/annotation/ClientHeaderParam.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/annotation/ClientHeaderParam.java
@@ -31,12 +31,12 @@ import java.lang.annotation.Target;
  * for both the type and the method, only the header value specified in the annotation on the method will be sent.
  * <p>
  * The value of the header to send can be specified explicitly by using the <code>value</code> attribute.
- * The value can also be computed via a default method on the client interface that returns a String value.  This method must be specified in the
- * <code>value</code> attribute but wrapped in curly-braces.
- * The default method's signature must either contain no arguments or a single <code>String</code> argument. The String argument is the name of the
- * header.
+ * The value can also be computed via a default method on the client interface or a public static method on a different class.  The compute method
+ * must return a String or String[] (indicating a multivalued header) value.  This method must be specified in the <code>value</code> attribute but
+ * wrapped in curly-braces. The compute method's signature must either contain no arguments or a single <code>String</code> argument. The String
+ * argument is the name of the header.
  * <p>
- * Here is an example using both approaches:
+ * Here is an example that explicitly defines a header value and computes a value:
  * <pre>
  * public interface MyClient {
  *
@@ -82,9 +82,9 @@ public @interface ClientHeaderParam {
     String name();
 
     /**
-     * @return the value of the HTTP header - or the method to invoke to get the value (surrounded by curly braces).
+     * @return the values of the HTTP header - or the method to invoke to get the value (surrounded by curly braces).
      */
-    String value();
+    String[] value();
 
     /**
      * @return whether to abort the request if the method to compute the header value throws an exception (true; default) or just skip this header

--- a/api/src/main/java/org/eclipse/microprofile/rest/client/annotation/ClientHeaderParams.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/annotation/ClientHeaderParams.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Used to specify HTTP parameters that should be sent with the outbound request.
+ * When this annotation is placed at the interface level of a REST client interface, the specified headers will be sent on each request for all
+ * methods in the interface.
+ * When this annotation is placed on a method, the headers will be sent only for that method. If the same HTTP header is specified in an annotation
+ * for both the type and the method, only the header value specified in the annotation on the method will be sent.
+ * <p>
+ * This class serves to act as the {@link java.lang.annotation.Repeatable} implementation for {@link ClientHeaderParam}.
+ *
+ * @since 1.2
+ */
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface ClientHeaderParams {
+    ClientHeaderParam[] value();
+}

--- a/spec/src/main/asciidoc/clientexamples.asciidoc
+++ b/spec/src/main/asciidoc/clientexamples.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 Contributors to the Eclipse Foundation
+// Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -79,6 +79,49 @@ public class PutUser {
 All built in HTTP methods are supported by the client API.  Likewise, all base parameter types (query, cookie, matrix, path, form and bean) are supported.  If you only need to inspect the body, you can provide a POJO can be processed by the underlying `MessageBodyReader` or `MessageBodyWriter`.  Otherwise, you can receive the entire `Response` object for parsing the body and header information from the server invocation.
 
 Users may specify the media (MIME) type of the outbound request using the `@Consumes` annotation (this determine the `Content-Type` HTTP header), and the expected media type(s) of the response by using the `@Produces` annotation (the `Accept` HTTP header).  This indicates that the client interface expects that the remote _service_ consumes/produces the specified types.
+
+=== Specifying Additional Client Headers
+
+While it is always possible to add a `@HeaderParam`-annotated method argument to specify headers, some times that does not make sense within the context of the application. For example, you may want to specify a username/password in the `Authorization` header to a secure remote service, but you may not want to have a `String authHeader` parameter in the client interface method.
+The `@ClientHeaderParam` annotation can allow users to specify HTTP headers that should be sent without altering the client interface method signature. The annotation contains three attributes: `name`, `value`. and `required`.  The name attribute is used to specify the header name. The value attribute is used to specify the value of the header. The value can be specified explicitly
+or it can reference a default method on the client interface that would compute the value of the header - in this latter case, the compute method name must be surrounded by curly braces. The compute method must be a default method on the interface, must return a `String` and must either contain no arguments or contain a single `String` argument - the implementation will use this
+`String` argument to pass the name of the header. The required attribute determines what should happen in the event that the compute method throws an exception. If the required attribute is set to true (default), then the client request will fail if the compute method throws an exception.  If it is set to false, then the client request will continue, but without sending the HTTP header.
+
+Note that if a `@ClientHeaderParam` annotation on a method specifies the same header name as an annotation on the client interface, the annotation on the method will take precedence. Likewise, if the same header name is used in a `@HeaderParam` annotation on a client interface method parameter or in a bean class when a `@BeanParam` annotation is on a client interface method
+parameter, the value of the `@HeaderParam` annotation takes precedence over any value specified in the `@ClientHeaderParam`.
+
+Here are a few examples:
+
+[source, java]
+----
+@Path("/somePath")
+public interface MyClient {
+
+    @POST
+    @ClientHeaderParam(name="X-Http-Method-Override", value="PUT")
+    Response sentPUTviaPOST(MyEntity entity);
+
+    @POST
+    @ClientHeaderParam(name="X-Request-ID", value="{generateRequestId}")
+    Response postWithRequestId(MyEntity entity);
+
+    @GET
+    @ClientHeaderParam(name="CustomHeader", value="{generateCustomHeader}",
+                       required=false)
+    Response getWithoutCustomHeader();
+
+    default String generateRequestId() {
+        return UUID.randomUUID().toString();
+    }
+
+    default String generateCustomHeader(String headerName) {
+        if ("CustomHeader".equals(headerName)) {
+            throw UnsupportedOperationException();
+        }
+        return "SomeValue";
+    }
+}
+----
 
 === Invalid Client Interface Examples
 

--- a/spec/src/main/asciidoc/clientexamples.asciidoc
+++ b/spec/src/main/asciidoc/clientexamples.asciidoc
@@ -83,12 +83,13 @@ Users may specify the media (MIME) type of the outbound request using the `@Cons
 === Specifying Additional Client Headers
 
 While it is always possible to add a `@HeaderParam`-annotated method argument to specify headers, some times that does not make sense within the context of the application. For example, you may want to specify a username/password in the `Authorization` header to a secure remote service, but you may not want to have a `String authHeader` parameter in the client interface method.
-The `@ClientHeaderParam` annotation can allow users to specify HTTP headers that should be sent without altering the client interface method signature. The annotation contains three attributes: `name`, `value`. and `required`.  The name attribute is used to specify the header name. The value attribute is used to specify the value of the header. The value can be specified explicitly
-or it can reference a default method on the client interface that would compute the value of the header - in this latter case, the compute method name must be surrounded by curly braces. The compute method must be a default method on the interface, must return a `String` and must either contain no arguments or contain a single `String` argument - the implementation will use this
-`String` argument to pass the name of the header. The required attribute determines what should happen in the event that the compute method throws an exception. If the required attribute is set to true (default), then the client request will fail if the compute method throws an exception.  If it is set to false, then the client request will continue, but without sending the HTTP header.
+The `@ClientHeaderParam` annotation can allow users to specify HTTP headers that should be sent without altering the client interface method signature. The annotation contains three attributes: `name`, `value`. and `required`.  The name attribute is used to specify the header name. The value attribute is used to specify the value(s) of the header. The value can be specified explicitly
+or it can reference a method that would compute the value of the header - in this latter case, the compute method name must be surrounded by curly braces. The compute method must be either a default method on the interface or a public static method that is accessible to the interface, must return a `String` or `String[]` and must either contain no arguments or contain a single `String`
+argument - the implementation will use this `String` argument to pass the name of the header. When specifying a compute method as the value attribute, only one method may be specified - if more than one string is specified as the value attribute, and one of the strings is a compute method (surrounded by curly braces), then the implementation will throw a RestClientDefinitionException.
+The required attribute determines what should happen in the event that the compute method throws an exception. **Note: If the required attribute is set to true (default), then the client request will fail if the compute method throws an exception.**  If it is set to false, then the client request will continue, but without sending the HTTP header.
 
 Note that if a `@ClientHeaderParam` annotation on a method specifies the same header name as an annotation on the client interface, the annotation on the method will take precedence. Likewise, if the same header name is used in a `@HeaderParam` annotation on a client interface method parameter or in a bean class when a `@BeanParam` annotation is on a client interface method
-parameter, the value of the `@HeaderParam` annotation takes precedence over any value specified in the `@ClientHeaderParam`.
+parameter, the value of the `@HeaderParam` annotation takes precedence over any value specified in the `@ClientHeaderParam`. It is invalid for the same header name to be specified in two different `@ClientHeaderParam` annotations on the same target - in this case, the implementation will throw a `RestClientDefinitionException.`
 
 Here are a few examples:
 
@@ -106,20 +107,31 @@ public interface MyClient {
     Response postWithRequestId(MyEntity entity);
 
     @GET
-    @ClientHeaderParam(name="CustomHeader", value="{generateCustomHeader}",
+    @ClientHeaderParam(name="CustomHeader",
+                       value="{some.pkg.MyHeaderGenerator.generateCustomHeader}",
                        required=false)
     Response getWithoutCustomHeader();
 
     default String generateRequestId() {
         return UUID.randomUUID().toString();
     }
+}
 
-    default String generateCustomHeader(String headerName) {
+public class MyHeaderGenerator {
+    public static String generateCustomHeader(String headerName) {
         if ("CustomHeader".equals(headerName)) {
             throw UnsupportedOperationException();
         }
         return "SomeValue";
     }
+}
+
+@Path("/someOtherPath")
+@ClientHeaderParam(name="CustomHeader", value="value1")
+@ClientHeaderParam(name="CustomHeader", value="{generateCustomHeader}")
+// will throw a RestClientDefinitionException at build time
+public interface MyInvalidClient {
+...
 }
 ----
 
@@ -191,3 +203,5 @@ public interface BadInterfaceThree {
 `BadInterfaceTwo` does not declare a URI template, but the `quickCheck` method specifies a `@PathParam` annotation on a parameter.
 `BadInterfaceThree` has a mismatch.  The `@Path` annotation declares a URI template named "someOtherParam" but the `@PathParam` annotation specifies a template named "notTheSameParam".
 All three interfaces will result in a RestClientDefinitionException.
+
+As previously mentioned, specifying the same header name in multiple `@ClientHeaderParam` annotations on the same target will result in a RestClientDefinitionException. Likewise, specifying multiple compute methods in the `@ClientHeaderParam` value attribute will result in a RestClientDefinitionException.

--- a/spec/src/main/asciidoc/release_notes.asciidoc
+++ b/spec/src/main/asciidoc/release_notes.asciidoc
@@ -23,6 +23,7 @@
 
 Changes since 1.1:
 
+- New `@ClientHeaderParam` API for defining HTTP headers without modifying the client interface method signature.
 - New section documenting the <<integration.asciidoc#integration>>.
 - Clarification on built-in JSON-B/JSON-P entity providers.
 - New `baseUri` property added to `@RegisterRestClient` annotation.

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ClientHeaderParamTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ClientHeaderParamTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2018 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.fail;
+
+import java.util.Map;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.tck.interfaces.ClientHeaderParamClient;
+import org.eclipse.microprofile.rest.client.tck.providers.ReturnWithAllClientHeadersFilter;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+public class ClientHeaderParamTest extends WiremockArquillianTest {
+    @Deployment
+    public static Archive<?> createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, ClientHeaderParamTest.class.getSimpleName()+".war")
+            .addClasses(ClientHeaderParamClient.class, ReturnWithAllClientHeadersFilter.class,
+                        WiremockArquillianTest.class);
+    }
+
+    private static ClientHeaderParamClient client(Class<?>... providers) {
+        try {
+        RestClientBuilder builder = RestClientBuilder.newBuilder().baseUri(getServerURI());
+        for (Class<?> provider : providers) {
+            builder.register(provider);
+        }
+        return builder.build(ClientHeaderParamClient.class);
+    }
+    catch (Throwable t) {
+        t.printStackTrace();
+        return null;
+    }
+    }
+
+    private static void stub(String expectedHeaderName, String expectedHeaderValue) {
+        stubFor(
+            get(urlEqualTo("/"))
+                .withHeader(expectedHeaderName, equalTo(expectedHeaderValue))
+                .willReturn(
+                    aResponse().withStatus(200)
+                               .withBody(expectedHeaderValue)));
+    }
+    @BeforeTest
+    public void resetWiremock() {
+        setupServer();
+    }
+
+    @Test
+    public void testExplicitClientHeaderParamOnInterface() {
+        stub("InterfaceHeaderExplicit", "interfaceExplicit");
+        assertEquals(client().interfaceExplicit(), "interfaceExplicit");
+    }
+    @Test
+    public void testExplicitClientHeaderParamOnMethod() {
+        stub("MethodHeaderExplicit", "methodExplicit");
+        assertEquals(client().methodExplicit(), "methodExplicit");
+    }
+
+    @Test
+    public void testHeaderParamOverridesExplicitClientHeaderParamOnInterface() {
+        stub("InterfaceHeaderExplicit", "header");
+        assertEquals(client().headerParamOverridesInterfaceExplicit("header"), "header");
+    }
+
+    @Test
+    public void testHeaderParamOverridesExplicitClientHeaderParamOnMethod() {
+        stub("MethodHeaderExplicit", "header2");
+        assertEquals(client().headerParamOverridesMethodExplicit("header2"), "header2");
+    }
+
+    @Test
+    public void testExplicitClientHeaderParamOnMethodOverridesClientHeaderParamOnInterface() {
+        stub("OverrideableExplicit", "overriddenMethodExplicit");
+        assertEquals(client().methodClientHeaderParamOverridesInterfaceExplicit(),
+                     "overriddenMethodExplicit");
+    }
+
+    @Test
+    public void testComputedClientHeaderParamOnInterface() {
+        stub("InterfaceHeaderComputed", "interfaceComputed");
+        assertEquals(client().interfaceComputed(), "interfaceComputed");
+    }
+
+    @Test
+    public void testComputedClientHeaderParamOnMethod() {
+        stub("MethodHeaderComputed", "MethodHeaderComputed-X");
+        assertEquals(client().methodComputed(), "MethodHeaderComputed-X");
+    }
+
+    @Test
+    public void testHeaderParamOverridesComputedClientHeaderParamOnInterface() {
+        stub("InterfaceHeaderComputed", "override");
+        assertEquals(client().headerParamOverridesInterfaceComputed("override"), "override");
+    }
+
+    @Test
+    public void testHeaderParamOverridesComputedClientHeaderParamOnMethod() {
+        stub("MethodHeaderComputed", "override2");
+        assertEquals(client().headerParamOverridesMethodComputed("override2"), "override2");
+    }
+
+    @Test
+    public void testComputedClientHeaderParamOnMethodOverridesClientHeaderParamOnInterface() {
+        stub("OverrideableComputed", "overriddenMethodComputed");
+        assertEquals(client().methodClientHeaderParamOverridesInterfaceComputed(),
+                     "overriddenMethodComputed");
+    }
+
+    @Test
+    public void testExceptionInRequiredComputeMethodThrowsClientErrorException() {
+        try {
+            client().methodRequiredComputeMethodFails();
+            fail("Expected exception to be thrown");
+        }
+        catch (Throwable t) {
+            if (t instanceof RuntimeException) {
+                assertEquals(t.getMessage(), "intentional");
+            }
+            else {
+                fail("Threw unexpected exception, " + t + ", expected RuntimeException");
+            }
+        }
+    }
+
+    @Test
+    public void testHeaderNotSentWhenExceptionThrownAndRequiredIsFalse() {
+        Map<String, String> headers = client(ReturnWithAllClientHeadersFilter.class)
+            .methodOptionalMethodHeaderNotSentWhenComputeThrowsException();
+
+        assertFalse(headers.containsKey("OptionalInterfaceHeader"));
+        assertFalse(headers.containsKey("OptionalMethodHeader"));
+
+        //sanity check that the filter did return _some_ headers
+        assertEquals(headers.get("OverrideableExplicit"), "overrideableInterfaceExplicit");
+        assertEquals(headers.get("InterfaceHeaderComputed"), "interfaceComputed");
+        assertEquals(headers.get("MethodHeaderExplicit"), "SomeValue");
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvalidInterfaceTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvalidInterfaceTest.java
@@ -25,7 +25,11 @@ import org.eclipse.microprofile.rest.client.tck.interfaces.MissingHeaderComputeM
 import org.eclipse.microprofile.rest.client.tck.interfaces.MissingPathParam;
 import org.eclipse.microprofile.rest.client.tck.interfaces.MissingPathParamSub;
 import org.eclipse.microprofile.rest.client.tck.interfaces.MissingUriTemplate;
+import org.eclipse.microprofile.rest.client.tck.interfaces.MultipleHeadersOnSameInterface;
+import org.eclipse.microprofile.rest.client.tck.interfaces.MultipleHeadersOnSameMethod;
 import org.eclipse.microprofile.rest.client.tck.interfaces.MultipleHTTPMethodAnnotations;
+import org.eclipse.microprofile.rest.client.tck.interfaces.MultiValueClientHeaderWithComputeMethodOnInterface;
+import org.eclipse.microprofile.rest.client.tck.interfaces.MultiValueClientHeaderWithComputeMethodOnMethod;
 import org.eclipse.microprofile.rest.client.tck.interfaces.TemplateMismatch;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -41,7 +45,9 @@ public class InvalidInterfaceTest extends Arquillian{
                          .addClasses(MissingPathParam.class, MissingPathParamSub.class,
                                      MissingUriTemplate.class, MultipleHTTPMethodAnnotations.class,
                                      TemplateMismatch.class, MissingHeaderComputeMethod.class,
-                                     InvalidComputeMethodSignature.class);
+                                     InvalidComputeMethodSignature.class, MultipleHeadersOnSameMethod.class,
+                                     MultipleHeadersOnSameInterface.class, MultiValueClientHeaderWithComputeMethodOnInterface.class,
+                                     MultiValueClientHeaderWithComputeMethodOnMethod.class);
     }
 
     @Test(expectedExceptions={RestClientDefinitionException.class})
@@ -77,5 +83,25 @@ public class InvalidInterfaceTest extends Arquillian{
     @Test(expectedExceptions={RestClientDefinitionException.class})
     public void testExceptionThrownWhenClientHeaderParamComputeValueSpecifiesMethodWithInvalidSignature() throws Exception {
         RestClientBuilder.newBuilder().baseUri(new URI("http://localhost:8080/")).build(InvalidComputeMethodSignature.class);
+    }
+
+    @Test(expectedExceptions={RestClientDefinitionException.class})
+    public void testExceptionThrownWhenMultipleClientHeaderParamsSpecifySameHeaderOnMethod() throws Exception {
+        RestClientBuilder.newBuilder().baseUri(new URI("http://localhost:8080/")).build(MultipleHeadersOnSameMethod.class);
+    }
+
+    @Test(expectedExceptions={RestClientDefinitionException.class})
+    public void testExceptionThrownWhenMultipleClientHeaderParamsSpecifySameHeaderOnInterface() throws Exception {
+        RestClientBuilder.newBuilder().baseUri(new URI("http://localhost:8080/")).build(MultipleHeadersOnSameInterface.class);
+    }
+
+    @Test(expectedExceptions={RestClientDefinitionException.class})
+    public void testExceptionThrownWhenMultipleHeaderValuesSpecifiedIncludeComputeMethodOnInterface() throws Exception {
+        RestClientBuilder.newBuilder().baseUri(new URI("http://localhost:8080/")).build(MultiValueClientHeaderWithComputeMethodOnInterface.class);
+    }
+
+    @Test(expectedExceptions={RestClientDefinitionException.class})
+    public void testExceptionThrownWhenMultipleHeaderValuesSpecifiedIncludeComputeMethodOnMethod() throws Exception {
+        RestClientBuilder.newBuilder().baseUri(new URI("http://localhost:8080/")).build(MultiValueClientHeaderWithComputeMethodOnMethod.class);
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvalidInterfaceTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvalidInterfaceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ import java.net.URI;
 
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.RestClientDefinitionException;
+import org.eclipse.microprofile.rest.client.tck.interfaces.InvalidComputeMethodSignature;
+import org.eclipse.microprofile.rest.client.tck.interfaces.MissingHeaderComputeMethod;
 import org.eclipse.microprofile.rest.client.tck.interfaces.MissingPathParam;
 import org.eclipse.microprofile.rest.client.tck.interfaces.MissingPathParamSub;
 import org.eclipse.microprofile.rest.client.tck.interfaces.MissingUriTemplate;
@@ -38,7 +40,8 @@ public class InvalidInterfaceTest extends Arquillian{
         return ShrinkWrap.create(WebArchive.class, InvalidInterfaceTest.class.getSimpleName()+".war")
                          .addClasses(MissingPathParam.class, MissingPathParamSub.class,
                                      MissingUriTemplate.class, MultipleHTTPMethodAnnotations.class,
-                                     TemplateMismatch.class);
+                                     TemplateMismatch.class, MissingHeaderComputeMethod.class,
+                                     InvalidComputeMethodSignature.class);
     }
 
     @Test(expectedExceptions={RestClientDefinitionException.class})
@@ -64,5 +67,15 @@ public class InvalidInterfaceTest extends Arquillian{
     @Test(expectedExceptions={RestClientDefinitionException.class})
     public void testExceptionThrownWhenInterfaceHasMethodWithMismatchedPathParameter() throws Exception {
         RestClientBuilder.newBuilder().baseUri(new URI("http://localhost:8080/")).build(TemplateMismatch.class);
+    }
+
+    @Test(expectedExceptions={RestClientDefinitionException.class})
+    public void testExceptionThrownWhenClientHeaderParamComputeValueSpecifiesMissingMethod() throws Exception {
+        RestClientBuilder.newBuilder().baseUri(new URI("http://localhost:8080/")).build(MissingHeaderComputeMethod.class);
+    }
+
+    @Test(expectedExceptions={RestClientDefinitionException.class})
+    public void testExceptionThrownWhenClientHeaderParamComputeValueSpecifiesMethodWithInvalidSignature() throws Exception {
+        RestClientBuilder.newBuilder().baseUri(new URI("http://localhost:8080/")).build(InvalidComputeMethodSignature.class);
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ext/HeaderGenerator.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ext/HeaderGenerator.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.rest.client.tck.ext;
+
+public class HeaderGenerator {
+
+    private HeaderGenerator() {
+    }
+
+    public static String[] generateHeader(String headerName) {
+        return new String[]{"value1", "value2"};
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/ClientHeaderParamClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/ClientHeaderParamClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Contributors to the Eclipse Foundation
+ * Copyright 2018 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam;
 @ClientHeaderParam(name="InterfaceHeaderComputed", value="{computeForInterface}")
 @ClientHeaderParam(name="OverrideableComputed", value="{computeForInterface2}")
 @ClientHeaderParam(name="OptionalInterfaceHeader", value="{fail}", required=false)
+@ClientHeaderParam(name="InterfaceMultiValuedHeaderExplicit", value={"abc", "xyz"})
 @Path("/")
 public interface ClientHeaderParamClient {
     @GET
@@ -78,6 +79,10 @@ public interface ClientHeaderParamClient {
     @ClientHeaderParam(name="WillCauseFailure", value="{fail}")
     String methodRequiredComputeMethodFails();
 
+    @GET
+    @ClientHeaderParam(name="MultiValueInvokedFromAnotherClass",
+                       value="{org.eclipse.microprofile.rest.client.tck.ext.HeaderGenerator.generateHeader}")
+    String methodComputeMultiValuedHeaderFromOtherClass();
 
     default String computeForInterface() {
         return "interfaceComputed";

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/ClientHeaderParamClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/ClientHeaderParamClient.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+import java.util.Map;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam;
+
+@ClientHeaderParam(name="InterfaceHeaderExplicit", value="interfaceExplicit")
+@ClientHeaderParam(name="OverrideableExplicit", value="overrideableInterfaceExplicit")
+@ClientHeaderParam(name="InterfaceHeaderComputed", value="{computeForInterface}")
+@ClientHeaderParam(name="OverrideableComputed", value="{computeForInterface2}")
+@ClientHeaderParam(name="OptionalInterfaceHeader", value="{fail}", required=false)
+@Path("/")
+public interface ClientHeaderParamClient {
+    @GET
+    String interfaceExplicit();
+
+    @GET
+    @ClientHeaderParam(name="MethodHeaderExplicit", value="methodExplicit")
+    String methodExplicit();
+
+    @GET
+    String headerParamOverridesInterfaceExplicit(@HeaderParam("InterfaceHeaderExplicit") String param);
+
+    @GET
+    @ClientHeaderParam(name="MethodHeaderExplicit", value="methodExplicit")
+    String headerParamOverridesMethodExplicit(@HeaderParam("MethodHeaderExplicit") String param);
+
+    @GET
+    @ClientHeaderParam(name="OverrideableExplicit", value="overriddenMethodExplicit")
+    String methodClientHeaderParamOverridesInterfaceExplicit();
+
+    @GET
+    String interfaceComputed();
+
+    @GET
+    @ClientHeaderParam(name="MethodHeaderComputed", value="{computeForMethod}")
+    String methodComputed();
+
+    @GET
+    String headerParamOverridesInterfaceComputed(@HeaderParam("InterfaceHeaderComputed") String param);
+
+    @GET
+    @ClientHeaderParam(name="MethodHeaderComputed", value="{computeForMethod2}")
+    String headerParamOverridesMethodComputed(@HeaderParam("MethodHeaderComputed") String param);
+
+    @GET
+    @ClientHeaderParam(name="OverrideableComputed", value="{computeForMethod3}")
+    String methodClientHeaderParamOverridesInterfaceComputed();
+
+    @GET
+    @ClientHeaderParam(name="OptionalMethodHeader", value="{fail}", required=false)
+    @ClientHeaderParam(name="MethodHeaderExplicit", value="SomeValue")
+    Map<String, String> methodOptionalMethodHeaderNotSentWhenComputeThrowsException();
+
+    @GET
+    @ClientHeaderParam(name="WillCauseFailure", value="{fail}")
+    String methodRequiredComputeMethodFails();
+
+
+    default String computeForInterface() {
+        return "interfaceComputed";
+    }
+
+    default String computeForInterface2(String headerName) {
+        return "overrideableComputed";
+    }
+
+    default String computeForMethod(String headerName) {
+        return headerName + "-X";
+    }
+
+    default String computeForMethod2(String headerName) {
+        return headerName;
+    }
+
+    default String computeForMethod3() {
+        return "overriddenMethodComputed";
+    }
+
+    default String fail() {
+        throw new RuntimeException("intentional");
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/InvalidComputeMethodSignature.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/InvalidComputeMethodSignature.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+import java.util.Date;
+import javax.ws.rs.GET;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.core.Response;
+import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam;
+
+public interface InvalidComputeMethodSignature {
+
+    default String invalidMethod(String headerName, String someOtherArg) {
+        return "should not be invoked - too many String args";
+    }
+
+    default String invalidMethod(String headerName, Integer someOtherArg) {
+        return "should not be invoked - unexpected Integer arg";
+    }
+
+    default String invalidMethod(ClientRequestContext context, ClientRequestContext someOtherArg) {
+        return "should not be invoked - too many ClientRequestContext args";
+    }
+
+    default String invalidMethod(ClientRequestContext context, Date someOtherArg) {
+        return "should not be invoked - unexpected Date arg";
+    }
+
+    default String invalidMethod(Double unexpectedArg) {
+        return "should not be invoked - unexpected Double arg";
+    }
+
+    @ClientHeaderParam(name="TestHeader", value="{invalidMethod}")
+    @GET
+    Response get();
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/MissingHeaderComputeMethod.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/MissingHeaderComputeMethod.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+
+import javax.ws.rs.GET;
+import javax.ws.rs.core.Response;
+import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam;
+
+public interface MissingHeaderComputeMethod {
+
+    @ClientHeaderParam(name="TestHeader", value="{missingMethod}")
+    @GET
+    Response get();
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/MultiValueClientHeaderWithComputeMethodOnInterface.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/MultiValueClientHeaderWithComputeMethodOnInterface.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+
+import javax.ws.rs.GET;
+import javax.ws.rs.core.Response;
+import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam;
+
+@ClientHeaderParam(name="TestHeader", value={"{computeHeader}", "SecondValue"})
+public interface MultiValueClientHeaderWithComputeMethodOnInterface {
+    default String computeHeader(String headerName) {
+        return "ValueFor" + headerName;
+    }
+
+    @GET
+    Response get();
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/MultiValueClientHeaderWithComputeMethodOnMethod.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/MultiValueClientHeaderWithComputeMethodOnMethod.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+
+import javax.ws.rs.GET;
+import javax.ws.rs.core.Response;
+import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam;
+
+
+public interface MultiValueClientHeaderWithComputeMethodOnMethod {
+    default String computeHeader(String headerName) {
+        return "ValueFor" + headerName;
+    }
+
+    @GET
+    @ClientHeaderParam(name="TestHeader", value={"InitialValue", "{computeHeader}"})
+    Response get();
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/MultipleHeadersOnSameInterface.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/MultipleHeadersOnSameInterface.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.core.Response;
+import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam;
+
+@ClientHeaderParam(name="IdenticalHeader", value="{computeMethod}")
+@ClientHeaderParam(name="IdenticalHeader", value="someValue")
+public interface MultipleHeadersOnSameInterface {
+
+    default String computeMethod(String headerName) {
+        return "someOtherValue";
+    }
+
+    @GET
+    Response get();
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/MultipleHeadersOnSameMethod.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/MultipleHeadersOnSameMethod.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.core.Response;
+import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam;
+
+public interface MultipleHeadersOnSameMethod {
+
+    default String computeMethod(String headerName) {
+        return "someOtherValue";
+    }
+
+    @ClientHeaderParam(name="IdenticalHeader", value="{computeMethod}")
+    @ClientHeaderParam(name="IdenticalHeader", value="someValue")
+    @GET
+    Response get();
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/ReturnWithAllClientHeadersFilter.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/ReturnWithAllClientHeadersFilter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.providers;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+
+
+public class ReturnWithAllClientHeadersFilter implements ClientRequestFilter {
+
+    @Context
+    HttpHeaders headers;
+
+    @Override
+    public void filter(ClientRequestContext clientRequestContext) throws IOException {
+        Map<String,String> allClientHeaders = new HashMap<>();
+        MultivaluedMap<String,String> clientHeaders = headers.getRequestHeaders();
+        for (String headerName : clientHeaders.keySet()) {
+            allClientHeaders.put(headerName, clientHeaders.getFirst(headerName));
+        }
+        clientRequestContext.abortWith(Response.ok(allClientHeaders).build());
+
+    }
+}


### PR DESCRIPTION
Includes spec document changes describing how to use `@ClientHeaderParam`, the annotation in the API (including javadoc) and TCK tests that test proper usage and exception conditions.

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>