### PR TITLE
[142] test timeouts with CDI

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/asynctests/CDIInvokeAsyncSimpleGetOperationTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/asynctests/CDIInvokeAsyncSimpleGetOperationTest.java
@@ -51,7 +51,7 @@ import org.testng.annotations.Test;
  * This test is the same as the {@link org.eclipse.microprofile.rest.client.tck.cditests.CDIInvokeSimpleGetOperationTest}
  * but uses async methods.
  */
-public class CDIInvokeSimpleGetOperationTest extends WiremockArquillianTest{
+public class CDIInvokeAsyncSimpleGetOperationTest extends WiremockArquillianTest{
     @Inject
     @RestClient
     private SimpleGetApiAsync api;
@@ -63,7 +63,7 @@ public class CDIInvokeSimpleGetOperationTest extends WiremockArquillianTest{
     public static WebArchive createDeployment() {
         String propertyName = SimpleGetApiAsync.class.getName()+"/mp-rest/url";
         String value = getStringURL();
-        String simpleName = CDIInvokeSimpleGetOperationTest.class.getSimpleName();
+        String simpleName = CDIInvokeAsyncSimpleGetOperationTest.class.getSimpleName();
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class, simpleName + ".jar")
             .addClasses(SimpleGetApiAsync.class, WiremockArquillianTest.class)
             .addAsManifestResource(new StringAsset(propertyName+"="+value), "microprofile-config.properties")

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/timeout/TimeoutBuilderIndependentOfMPConfigTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/timeout/TimeoutBuilderIndependentOfMPConfigTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.timeout;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.tck.WiremockArquillianTest;
+import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.Assert.assertTrue;
+
+public class TimeoutBuilderIndependentOfMPConfigTest extends TimeoutTestBase {
+
+    @Deployment
+    public static Archive<?> createDeployment() {
+        String clientName = SimpleGetApi.class.getName();
+        String timeoutProps = clientName + "/mp-rest/connectTimeout=7000" +
+                              System.lineSeparator() +
+                              clientName + "/mp-rest/readTimeout=7000";
+        StringAsset mpConfig = new StringAsset(timeoutProps);
+        return ShrinkWrap.create(WebArchive.class, TimeoutBuilderIndependentOfMPConfigTest.class.getSimpleName()+".war")
+            .addAsWebInfResource(mpConfig, "classes/META-INF/microprofile-config.properties")
+            .addClasses(SimpleGetApi.class,
+                        TimeoutTestBase.class,
+                        WiremockArquillianTest.class);
+    }
+
+    @Override
+    protected SimpleGetApi getClientWithReadTimeout() {
+        return RestClientBuilder.newBuilder()
+            .baseUri(WiremockArquillianTest.getServerURI())
+            .readTimeout(5, TimeUnit.SECONDS)
+            .build(SimpleGetApi.class);
+    }
+
+    @Override
+    protected SimpleGetApi getClientWithConnectTimeout() {
+        return RestClientBuilder.newBuilder()
+            .baseUri(URI.create(UNUSED_URL))
+            .connectTimeout(5, TimeUnit.SECONDS)
+            .build(SimpleGetApi.class);
+    }
+
+    @Override
+    protected void checkTimeElapsed(long elapsed) {
+        assertTrue(elapsed >= 5);
+        // allow an extra 10 seconds cushion for slower test machines
+        assertTrue(elapsed < 15);
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/timeout/TimeoutBuilderIndependentOfMPConfigTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/timeout/TimeoutBuilderIndependentOfMPConfigTest.java
@@ -37,9 +37,9 @@ public class TimeoutBuilderIndependentOfMPConfigTest extends TimeoutTestBase {
     @Deployment
     public static Archive<?> createDeployment() {
         String clientName = SimpleGetApi.class.getName();
-        String timeoutProps = clientName + "/mp-rest/connectTimeout=7000" +
+        String timeoutProps = clientName + "/mp-rest/connectTimeout=15000" +
                               System.lineSeparator() +
-                              clientName + "/mp-rest/readTimeout=7000";
+                              clientName + "/mp-rest/readTimeout=15000";
         StringAsset mpConfig = new StringAsset(timeoutProps);
         return ShrinkWrap.create(WebArchive.class, TimeoutBuilderIndependentOfMPConfigTest.class.getSimpleName()+".war")
             .addAsWebInfResource(mpConfig, "classes/META-INF/microprofile-config.properties")

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/timeout/TimeoutTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/timeout/TimeoutTest.java
@@ -16,13 +16,15 @@
  * limitations under the License.
  */
 
-package org.eclipse.microprofile.rest.client.tck;
+package org.eclipse.microprofile.rest.client.tck.timeout;
 
 import static org.testng.Assert.assertTrue;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
 
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.tck.WiremockArquillianTest;
 import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.Archive;
@@ -31,12 +33,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 public class TimeoutTest extends TimeoutTestBase {
 
-    private static final int UNUSED_PORT =
-        AccessController.doPrivileged((PrivilegedAction<Integer>) () -> {
-            return Integer.getInteger(
-                "org.eclipse.microprofile.rest.client.tck.unusedPort", 23);
-        });
-
     @Deployment
     public static Archive<?> createDeployment() {
         String simpleName = TimeoutTest.class.getSimpleName();
@@ -44,6 +40,22 @@ public class TimeoutTest extends TimeoutTestBase {
                          .addClasses(WiremockArquillianTest.class,
                                      TimeoutTestBase.class,
                                      SimpleGetApi.class);
+    }
+
+    @Override
+    protected SimpleGetApi getClientWithReadTimeout() {
+        return RestClientBuilder.newBuilder()
+            .baseUri(WiremockArquillianTest.getServerURI())
+            .readTimeout(5, TimeUnit.SECONDS)
+            .build(SimpleGetApi.class);
+    }
+
+    @Override
+    protected SimpleGetApi getClientWithConnectTimeout() {
+        return RestClientBuilder.newBuilder()
+            .baseUri(URI.create(UNUSED_URL))
+            .connectTimeout(5, TimeUnit.SECONDS)
+            .build(SimpleGetApi.class);
     }
 
     @Override

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/timeout/TimeoutViaMPConfigTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/timeout/TimeoutViaMPConfigTest.java
@@ -16,32 +16,52 @@
  * limitations under the License.
  */
 
-package org.eclipse.microprofile.rest.client.tck;
+package org.eclipse.microprofile.rest.client.tck.timeout;
 
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.eclipse.microprofile.rest.client.tck.WiremockArquillianTest;
 import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+import javax.inject.Inject;
 
 import static org.testng.Assert.assertTrue;
 
 public class TimeoutViaMPConfigTest extends TimeoutTestBase {
 
+    @Inject
+    @RestClient
+    private SimpleGetApi api;
+
     @Deployment
     public static Archive<?> createDeployment() {
         String clientName = SimpleGetApi.class.getName();
-        String timeoutProps = clientName + "/mp-rest/connectTimeout=7000" +
-                              System.lineSeparator() +
-                              clientName + "/mp-rest/readTimeout=7000";
+        String timeoutProps =
+                clientName + "/mp-rest/uri=" + UNUSED_URL + System.lineSeparator() +
+                clientName + "/mp-rest/connectTimeout=7000" + System.lineSeparator() +
+                clientName + "/mp-rest/readTimeout=7000";
         StringAsset mpConfig = new StringAsset(timeoutProps);
         return ShrinkWrap.create(WebArchive.class, TimeoutViaMPConfigTest.class.getSimpleName()+".war")
             .addAsWebInfResource(mpConfig, "classes/META-INF/microprofile-config.properties")
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
             .addClasses(SimpleGetApi.class,
-                        TimeoutTest.class,
                         TimeoutTestBase.class,
                         WiremockArquillianTest.class);
+    }
+
+    @Override
+    protected SimpleGetApi getClientWithReadTimeout() {
+        return api;
+    }
+
+    @Override
+    protected SimpleGetApi getClientWithConnectTimeout() {
+        return api;
     }
 
     @Override


### PR DESCRIPTION
+ test that MP Config timeouts don't impact programmatically created clients
+ rename of the async CDIInvokeSimpleGetOperationTest to fix intermittent failures caused by the name clash

fixes #142 