### PR TITLE
Minor typo corrections for final 1.2 release

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
@@ -111,7 +111,8 @@ public interface RestClientBuilder extends Configurable<RestClientBuilder> {
      * infinity, and negative values are not allowed.
      * </p>
      * <p>
-     * If the &quot;<em>fully.qualified.InterfaceName</em>/mp-rest/connectTimeout@quot;
+     * If the client instance is injected via CDI and the
+     * &quot;<em>fully.qualified.InterfaceName</em>/mp-rest/connectTimeout&quot;
      * property is set via MicroProfile Config, that property's value will
      * override, the value specified to this method.
      * </p>
@@ -136,7 +137,8 @@ public interface RestClientBuilder extends Configurable<RestClientBuilder> {
      * client interface method will throw a <code>javax.ws.rs.ProcessingException</code>.
      * </p>
      * <p>
-     * If the &quot;<em>fully.qualified.InterfaceName</em>/mp-rest/readTimeout@quot;
+     * If the client instance is injected via CDI and the
+     * &quot;<em>fully.qualified.InterfaceName</em>/mp-rest/readTimeout&quot;
      * property is set via MicroProfile Config, that property's value will
      * override, the value specified to this method.
      * </p>

--- a/spec/src/main/asciidoc/async.asciidoc
+++ b/spec/src/main/asciidoc/async.asciidoc
@@ -42,7 +42,7 @@ public interface MyAsyncClient {
 
 By default, the MicroProfile Rest Client implementation can determine how to implement the asynchronous request.
 The primary requirement for the implementation is that the response from the remote server should be handled on a different thread than the thread invoking the asynchronous method.
-Providers on the outbound client request chain (such as `ClientRequestFilter`s, `MessageBodyWriter`s, `WriterInterceptor`s, etc.) may be executed on either thread.
+Providers on the outbound client request chain (such as providers of type `ClientRequestFilter`, `MessageBodyWriter`, `WriterInterceptor`, etc.) may be executed on either thread.
 
 Callers may override the default implementation by providing their own `ExecutorService` via the `RestClientBuilder.executorService(ExecutorService)` method.
 The implementation must use the `ExecutorService` provided for all asynchronous methods on any interface built via the `RestClientBuilder`.
@@ -54,9 +54,9 @@ This can be accomplished by registering an implementation of the AsyncInvocation
 MP Rest Client implementations must invoke the `newInterceptor` method of each registered factory provider prior to switching thread of execution on async method requests.
 That method will return an instance of `AsyncInvocationInterceptor` - the MP Rest Client implementation must then invoke the `prepareContext` method while still executing on the thread that invoked the async method.
 After swapping threads, but before invoking further providers or returning control back to the async method caller, the MP Rest Client implementation must invoke the `applyContext` method on the new async thread that will complete the request/response.
-The implementation must then invoke all inbound response providers (filters, interceptors, MessageBodyReaders, etc.) and then must invoke the `AsyncInvocationInterceptor`'s `removeContext` method.  This allows the provider to remove any contexts from the thread before returning control back to the user.
+The implementation must then invoke all inbound response providers (filters, interceptors, MessageBodyReaders, etc.) and then must invoke the `removeContext` method on the `AsyncInvocationInterceptor`.  This allows the provider to remove any contexts from the thread before returning control back to the user.
 
-The following example shows how the AsyncInvocationInterceptorFactory provider and associated AsyncInvocationInterceptor interface could be used to propagate a `ThreadLocal` value from the originating thread to async thread:
+The following example shows how the `AsyncInvocationInterceptorFactory` provider and associated `AsyncInvocationInterceptor` interface could be used to propagate a `ThreadLocal` value from the originating thread to async thread:
 [source, java]
 ----
 public class MyFactory implements AsyncInvocationInterceptorFactory {

--- a/spec/src/main/asciidoc/cdi.asciidoc
+++ b/spec/src/main/asciidoc/cdi.asciidoc
@@ -48,7 +48,8 @@ Likewise, a user can perform programmatic look up of the interface.  Here is one
 @ApplicationScoped
 public class MyService {
     public void execute() {
-        MyServiceClient client = CDI.current().select(MyServiceClient.class, RestClient.LITERAL).get();
+        MyServiceClient client = CDI.current().select(MyServiceClient.class,
+                                                      RestClient.LITERAL).get();
     }
 }
 ----
@@ -88,4 +89,4 @@ Implementations may support other custom properties registered in similar fashio
 The `url` property must resolve to a value that can be parsed by the `URL` converter required by the MicroProfile Config spec. Likewise, the `uri` property must resolve to a value that can be parsed by the `URI` converter.
 If both the `url` and `uri` properties are declared, then the `uri` property will take precedence.
 
-The `providers` property is not aggregated, the value will be read from the highest property `ConfigSource`
+The `providers` property is not aggregated, the value will be read from the highest property `ConfigSource`.

--- a/spec/src/main/asciidoc/clientexamples.asciidoc
+++ b/spec/src/main/asciidoc/clientexamples.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
+// Copyright (c) 2017-2019 Contributors to the Eclipse Foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -56,7 +56,8 @@ public interface UsersClient {
     Response headUser(@PathParam("userId") String userId);
 
     @POST
-    Response createUser(@HeaderParam("Authorization") String authorization, User user);
+    Response createUser(@HeaderParam("Authorization") String authorization,
+                                                      User user);
 
     @PUT
     @Path("/{userId}")
@@ -64,7 +65,8 @@ public interface UsersClient {
 
     @DELETE
     @Path("/{userId}")
-    Response deleteUser(@CookieParam("AuthToken") String authorization, @PathParam("userId") String userId);
+    Response deleteUser(@CookieParam("AuthToken") String authorization,
+                        @PathParam("userId") String userId);
 }
 
 public class PutUser {
@@ -83,10 +85,12 @@ Users may specify the media (MIME) type of the outbound request using the `@Cons
 === Specifying Additional Client Headers
 
 While it is always possible to add a `@HeaderParam`-annotated method argument to specify headers, some times that does not make sense within the context of the application. For example, you may want to specify a username/password in the `Authorization` header to a secure remote service, but you may not want to have a `String authHeader` parameter in the client interface method.
-The `@ClientHeaderParam` annotation can allow users to specify HTTP headers that should be sent without altering the client interface method signature. The annotation contains three attributes: `name`, `value`. and `required`.  The name attribute is used to specify the header name. The value attribute is used to specify the value(s) of the header. The value can be specified explicitly
+The `@ClientHeaderParam` annotation can allow users to specify HTTP headers that should be sent without altering the client interface method signature.
+
+The annotation contains three attributes: `name`, `value`. and `required`.  The `name` attribute is used to specify the header name. The `value` attribute is used to specify the value(s) of the header. The value can be specified explicitly
 or it can reference a method that would compute the value of the header - in this latter case, the compute method name must be surrounded by curly braces. The compute method must be either a default method on the interface or a public static method that is accessible to the interface, must return a `String` or `String[]` and must either contain no arguments or contain a single `String`
 argument - the implementation will use this `String` argument to pass the name of the header. When specifying a compute method as the value attribute, only one method may be specified - if more than one string is specified as the value attribute, and one of the strings is a compute method (surrounded by curly braces), then the implementation will throw a RestClientDefinitionException.
-The required attribute determines what should happen in the event that the compute method throws an exception. **Note: If the required attribute is set to true (default), then the client request will fail if the compute method throws an exception.**  If it is set to false, then the client request will continue, but without sending the HTTP header.
+The `required` attribute determines what should happen in the event that the compute method throws an exception. **Note: If the required attribute is set to true (default), then the client request will fail if the compute method throws an exception.**  If it is set to false and the compute method throws an exception, then the client request will continue, but without sending the HTTP header.
 
 Note that if a `@ClientHeaderParam` annotation on a method specifies the same header name as an annotation on the client interface, the annotation on the method will take precedence. Likewise, if the same header name is used in a `@HeaderParam` annotation on a client interface method parameter or in a bean class when a `@BeanParam` annotation is on a client interface method
 parameter, the value of the `@HeaderParam` annotation takes precedence over any value specified in the `@ClientHeaderParam`. It is invalid for the same header name to be specified in two different `@ClientHeaderParam` annotations on the same target - in this case, the implementation will throw a `RestClientDefinitionException.`
@@ -135,10 +139,14 @@ public interface MyInvalidClient {
 }
 ----
 
-It is also possible to add or propagate headers en masse using a `ClientHeadersFactory`. This interface has a single method and takes two read-only `MultivaluedMap`s as parameters: The first map represents headers for the incoming request - if the client is executing in a JAX-RS environment then this map will contain headers from the inbound JAX-RS request. The second map represents the headers to be sent,
+It is also possible to add or propagate headers en masse using a `ClientHeadersFactory`. This interface has a single method and takes two read-only `MultivaluedMap` parameters: The first map represents headers for the incoming request - if the client is executing in a JAX-RS environment then this map will contain headers from the inbound JAX-RS request. The second map represents the headers to be sent,
 and it contains headers that have been specified via `@ClientHeaderParam`, `@HeaderParam`, `@BeanParam`, etc. The method should return a `MultivaluedMap` that contains the headers to merge with this second map for the "final" map of headers to be sent to the outbound processing flow. Providers such as filters, interceptors, message body writers, etc. could still modify the final map of headers prior to
-sending the HTTP request. By default, no `ClientHeadersFactory` implementation is used. To enable a `ClientHeadersFactory`, the client interface must be annotated with the `@RegisterClientHeaders` annotation. If this annotation specifies a value, the client implementation must invoke an instance of the specified `ClientHeadersFactory` implementation class. If no value is specified, then the client
-implementation must invoke the `DefaultClientHeadersFactoryImpl`. This default factory will propagate specified headers from the inbound JAX-RS request to the outbound request - these headers are specified with a comma-separated list using the MicroProfile Config property, `org.eclipse.microprofile.rest.client.propagateHeaders`.
+sending the HTTP request.
+
+By default, no `ClientHeadersFactory` implementation is used. To enable a `ClientHeadersFactory`, the client interface must be annotated with the `@RegisterClientHeaders` annotation. If this annotation specifies a value, the client implementation must invoke an instance of the specified `ClientHeadersFactory` implementation class. If no value is specified, then the client
+implementation must invoke the `DefaultClientHeadersFactoryImpl`. This default factory will propagate specified headers from the inbound JAX-RS request to the outbound request - these headers are specified with a comma-separated list using the following MicroProfile Config property:
+
+`org.eclipse.microprofile.rest.client.propagateHeaders`
 
 === Invalid Client Interface Examples
 

--- a/spec/src/main/asciidoc/integration.asciidoc
+++ b/spec/src/main/asciidoc/integration.asciidoc
@@ -48,7 +48,9 @@ interrupt the request and the throw the appropriate `TimeoutException`.
 
 When a client interface is executed from within a JAX-RS context (resource or provider class), it is possible to propagate HTTP headers using the `DefaultClientHeadersFactoryImpl` by adding the
 `@RegisterClientHeaders` annotation to the interface with no value. To specify which headers to propagate from the inbound JAX-RS request to the outbound MP Rest Client request, users must use a
-comma-separated list of headers in the MicroProfile Config property, `org.eclipse.microprofile.rest.client.propagateHeaders`.
+comma-separated list of headers in the following MicroProfile Config property:
+
+`org.eclipse.microprofile.rest.client.propagateHeaders`.
 
 === Other MicroProfile Technologies
 

--- a/spec/src/main/asciidoc/license-alv2.asciidoc
+++ b/spec/src/main/asciidoc/license-alv2.asciidoc
@@ -25,7 +25,7 @@ Status: {revremark}
 
 Release: {revdate}
 
-Copyright (c) 2017 Contributors to the Eclipse Foundation
+Copyright (c) 2017-2019 Contributors to the Eclipse Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/spec/src/main/asciidoc/microprofile-rest-client.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-rest-client.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
+// Copyright (c) 2017-2019 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/spec/src/main/asciidoc/providers.asciidoc
+++ b/spec/src/main/asciidoc/providers.asciidoc
@@ -90,7 +90,7 @@ Any methods that read the response body as a stream must ensure that they reset 
 
 == Provider Declaration
 
-In addition to defining providers via the client definition, interfaces may use the `@RegisterProvider` annotation to define classes to be registered as providers in addition to providers registered via the `RestClientBuilder`
+In addition to defining providers via the client definition, interfaces may use the `@RegisterProvider` annotation to define classes to be registered as providers in addition to providers registered via the `RestClientBuilder`.
 
 Providers may also be registered by implementing the `RestClientBuilderListener` or `RestClientListener` interfaces.  These interfaces are intended as SPIs to allow global provider registration.  The implementation of these interface must be specified in a `META-INF/services/org.eclipse.microprofile.rest.client.spi.RestClientBuilderListener` or `META-INF/services/org.eclipse.microprofile.rest.client.spi.RestClientListener` file, respectively, following the `ServiceLoader` pattern.
 


### PR DESCRIPTION
Fixing minor typos (missing periods, messed up apostrophes, `@quot;` instead of `&quot;` in the javadocs, etc.).

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>