### PR TITLE
Switch ReturnWithAllClientHeadersFilter to JsonObject

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ClientHeaderParamTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ClientHeaderParamTest.java
@@ -40,6 +40,8 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
+import javax.json.JsonObject;
+
 public class ClientHeaderParamTest extends WiremockArquillianTest {
     @Deployment
     public static Archive<?> createDeployment() {
@@ -163,16 +165,16 @@ public class ClientHeaderParamTest extends WiremockArquillianTest {
 
     @Test
     public void testHeaderNotSentWhenExceptionThrownAndRequiredIsFalse() {
-        Map<String, String> headers = client(ReturnWithAllClientHeadersFilter.class)
+        JsonObject headers = client(ReturnWithAllClientHeadersFilter.class)
             .methodOptionalMethodHeaderNotSentWhenComputeThrowsException();
 
         assertFalse(headers.containsKey("OptionalInterfaceHeader"));
         assertFalse(headers.containsKey("OptionalMethodHeader"));
 
         //sanity check that the filter did return _some_ headers
-        assertEquals(headers.get("OverrideableExplicit"), "overrideableInterfaceExplicit");
-        assertEquals(headers.get("InterfaceHeaderComputed"), "interfaceComputed");
-        assertEquals(headers.get("MethodHeaderExplicit"), "SomeValue");
+        assertEquals(headers.getString("OverrideableExplicit"), "overrideableInterfaceExplicit");
+        assertEquals(headers.getString("InterfaceHeaderComputed"), "interfaceComputed");
+        assertEquals(headers.getString("MethodHeaderExplicit"), "SomeValue");
     }
 
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ClientHeadersFactoryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ClientHeadersFactoryTest.java
@@ -22,7 +22,6 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 
 import java.net.URI;
-import java.util.Map;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.tck.interfaces.ClientHeadersFactoryClient;
 import org.eclipse.microprofile.rest.client.tck.ext.CustomClientHeadersFactory;
@@ -33,6 +32,8 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
+
+import javax.json.JsonObject;
 
 public class ClientHeadersFactoryTest extends Arquillian {
     @Deployment
@@ -61,7 +62,7 @@ public class ClientHeadersFactoryTest extends Arquillian {
         CustomClientHeadersFactory.isOutgoingHeadersMapNull = true;
         CustomClientHeadersFactory.passedInOutgoingHeaders.clear();
 
-        Map<String, String> headers = client(ReturnWithAllClientHeadersFilter.class).delete("argValue");
+        JsonObject headers = client(ReturnWithAllClientHeadersFilter.class).delete("argValue");
 
         assertFalse(CustomClientHeadersFactory.isIncomingHeadersMapNull);
         assertFalse(CustomClientHeadersFactory.isOutgoingHeadersMapNull);
@@ -70,9 +71,9 @@ public class ClientHeadersFactoryTest extends Arquillian {
         assertEquals(CustomClientHeadersFactory.passedInOutgoingHeaders.getFirst("ArgHeader"), "argValue");
 
 
-        assertEquals(headers.get("IntfHeader"), "intfValueModified");
-        assertEquals(headers.get("MethodHeader"), "methodValueModified");
-        assertEquals(headers.get("ArgHeader"), "argValueModified");
-        assertEquals(headers.get("FactoryHeader"), "factoryValue");
+        assertEquals(headers.getString("IntfHeader"), "intfValueModified");
+        assertEquals(headers.getString("MethodHeader"), "methodValueModified");
+        assertEquals(headers.getString("ArgHeader"), "argValueModified");
+        assertEquals(headers.getString("FactoryHeader"), "factoryValue");
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/ClientHeaderParamClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/ClientHeaderParamClient.java
@@ -18,8 +18,7 @@
 
 package org.eclipse.microprofile.rest.client.tck.interfaces;
 
-import java.util.Map;
-
+import javax.json.JsonObject;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
@@ -73,7 +72,7 @@ public interface ClientHeaderParamClient {
     @GET
     @ClientHeaderParam(name="OptionalMethodHeader", value="{fail}", required=false)
     @ClientHeaderParam(name="MethodHeaderExplicit", value="SomeValue")
-    Map<String, String> methodOptionalMethodHeaderNotSentWhenComputeThrowsException();
+    JsonObject methodOptionalMethodHeaderNotSentWhenComputeThrowsException();
 
     @GET
     @ClientHeaderParam(name="WillCauseFailure", value="{fail}")

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/ClientHeadersFactoryClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/ClientHeadersFactoryClient.java
@@ -18,8 +18,7 @@
 
 package org.eclipse.microprofile.rest.client.tck.interfaces;
 
-import java.util.Map;
-
+import javax.json.JsonObject;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
@@ -35,5 +34,5 @@ import org.eclipse.microprofile.rest.client.tck.ext.CustomClientHeadersFactory;
 public interface ClientHeadersFactoryClient {
     @DELETE
     @ClientHeaderParam(name="MethodHeader", value="methodValue")
-    Map<String, String> delete(@HeaderParam("ArgHeader") String argHeader);
+    JsonObject delete(@HeaderParam("ArgHeader") String argHeader);
 }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/ReturnWithAllClientHeadersFilter.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/ReturnWithAllClientHeadersFilter.java
@@ -18,16 +18,15 @@
 
 package org.eclipse.microprofile.rest.client.tck.providers;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-
+import javax.json.Json;
+import javax.json.JsonObjectBuilder;
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
+import java.io.IOException;
 
 
 public class ReturnWithAllClientHeadersFilter implements ClientRequestFilter {
@@ -37,12 +36,12 @@ public class ReturnWithAllClientHeadersFilter implements ClientRequestFilter {
 
     @Override
     public void filter(ClientRequestContext clientRequestContext) throws IOException {
-        Map<String,String> allClientHeaders = new HashMap<>();
+        JsonObjectBuilder allClientHeaders = Json.createObjectBuilder();
         MultivaluedMap<String,String> clientHeaders = headers.getRequestHeaders();
         for (String headerName : clientHeaders.keySet()) {
-            allClientHeaders.put(headerName, clientHeaders.getFirst(headerName));
+            allClientHeaders.add(headerName, clientHeaders.getFirst(headerName));
         }
-        clientRequestContext.abortWith(Response.ok(allClientHeaders).build());
+        clientRequestContext.abortWith(Response.ok(allClientHeaders.build()).build());
 
     }
 }


### PR DESCRIPTION
Changed `ClientHeaderParamClient#methodOptionalMethodHeaderNotSentWhenComputeThrowsException`
and `ClientHeadersFactoryClient#delete` to return `JsonObject`

Signed-off-by: Michal Szynkiewicz <michal.l.szynkiewicz@gmail.com>