### PR TITLE
chore: rename WildFly-Swarm to Thorntail

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -78,7 +78,7 @@ The following Implementations are available
 
 * Apache CXF (http://cxf.apache.org/download.html)
 * OpenLiberty (https://openliberty.io/blog/2018/01/31/mpRestClient.html)
-* wildfly-swarm (https://github.com/wildfly-swarm/wildfly-swarm/tree/master/fractions/microprofile/microprofile-restclient)
+* Thorntail (https://github.com/thorntail/thorntail/tree/master/fractions/microprofile/microprofile-restclient)
 
 == Contributing
 


### PR DESCRIPTION
WildFly Swarm was renamed to Thorntail on June, 2018