### PR TITLE
ISSUE #166 - Fix TCK InvokeWithJsonBProviderTest getTest JSON body

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeWithJsonBProviderTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeWithJsonBProviderTest.java
@@ -92,9 +92,9 @@ public class InvokeWithJsonBProviderTest extends WiremockArquillianTest{
             .willReturn(aResponse()
                 .withHeader("Content-Type", "application/json")
                 .withBody("{" +
-                             "\"objectName\": \"myObject\"};" +
-                             "\"quantity\": 17;" +
-                             "\"date\": \"2018-12-04\";" +
+                             "\"objectName\": \"myObject\"," +
+                             "\"quantity\": \"17\"," +
+                             "\"date\": \"2018-12-04\"" +
                           "}")
                     ));
 


### PR DESCRIPTION
The invalid test body structure for myObject causes the test to fail