### PR TITLE
Issue 115: Support ConfigKeys for simpler configuration

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/rest/client/inject/RegisterRestClient.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/inject/RegisterRestClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Contributors to the Eclipse Foundation
+ * Copyright 2017-2019 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,4 +41,5 @@ import javax.enterprise.inject.Stereotype;
 @Dependent
 public @interface RegisterRestClient {
     String baseUri() default "";
+    String configKey() default "";
 }

--- a/spec/src/main/asciidoc/cdi.asciidoc
+++ b/spec/src/main/asciidoc/cdi.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
+// Copyright (c) 2017-2019 Contributors to the Eclipse Foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -67,6 +67,7 @@ For CDI defined interfaces, it is possible to use MicroProfile Config properties
 ----
 package com.mycompany.remoteServices;
 
+@RegisterRestClient
 public interface MyServiceClient {
     @GET
     @Path("/greet")
@@ -90,3 +91,32 @@ The `url` property must resolve to a value that can be parsed by the `URL` conve
 If both the `url` and `uri` properties are declared, then the `uri` property will take precedence.
 
 The `providers` property is not aggregated, the value will be read from the highest property `ConfigSource`.
+
+=== Configuration Keys
+
+It is possible to simplify configuration of client interfaces by using configuration keys. Config keys are specified in the `@RegisterRestClient` annotation and can be used in place of the fully-qualified classname in MP Config. For example, if we modify the previous example to be:
+
+[source, java]
+----
+package com.mycompany.remoteServices;
+
+@RegisterRestClient(configKey="myClient")
+public interface MyServiceClient {
+    @GET
+    @Path("/greet")
+    Response greet();
+}
+----
+
+Then config properties can be specified like:
+- `myClient/mp-rest/url`
+- `myClient/mp-rest/uri`
+- `myClient/mp-rest/scope`
+- `myClient/mp-rest/providers`
+- `myClient/mp-rest/providers/com.mycompany.MyProvider/priority`
+- `myClient/mp-rest/connectTimeout`
+- `myClient/mp-rest/readTimeout`
+
+Multiple client interfaces may have the same configKey value, which would allow many interfaces to be configured with a single MP Config property.
+
+If the same property exists for the same interface specified by both the configKey and the fully-qualified classname, the property specified by the fully-qualified classname takes precedence.

--- a/spec/src/main/asciidoc/release_notes.asciidoc
+++ b/spec/src/main/asciidoc/release_notes.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016-2018 Contributors to the Eclipse Foundation
+// Copyright (c) 2016-2019 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.
@@ -17,6 +17,14 @@
 // limitations under the License.
 // Contributors:
 // John D. Ament, Andy McCright
+
+[[release_notes_13]]
+== Release Notes for MicroProfile Rest Client 1.3
+
+Changes since 1.2:
+
+- Simpler configuration using configKeys.
+- Defined `application/json` to be the default MediaType if none is specified in `@Produces`/`@Consumes`.
 
 [[release_notes_12]]
 == Release Notes for MicroProfile Rest Client 1.2

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/CDIInvokeWithRegisteredProvidersTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/CDIInvokeWithRegisteredProvidersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Contributors to the Eclipse Foundation
+ * Copyright 2017-2019 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.eclipse.microprofile.rest.client.tck.WiremockArquillianTest;
 import org.eclipse.microprofile.rest.client.tck.interfaces.InterfaceBase;
 import org.eclipse.microprofile.rest.client.tck.interfaces.InterfaceWithProvidersDefined;
 import org.eclipse.microprofile.rest.client.tck.interfaces.InterfaceWithoutProvidersDefined;
+import org.eclipse.microprofile.rest.client.tck.interfaces.InterfaceWithoutProvidersDefinedWithConfigKey;
 import org.eclipse.microprofile.rest.client.tck.providers.TestClientRequestFilter;
 import org.eclipse.microprofile.rest.client.tck.providers.TestClientResponseFilter;
 import org.eclipse.microprofile.rest.client.tck.providers.TestMessageBodyReader;
@@ -66,10 +67,15 @@ public class CDIInvokeWithRegisteredProvidersTest extends WiremockArquillianTest
     @RestClient
     private InterfaceWithoutProvidersDefined clientProvidersViaMPConfig;
 
+    @Inject
+    @RestClient
+    private InterfaceWithoutProvidersDefinedWithConfigKey clientProvidersViaConfigKey;
+
     @Deployment
     public static WebArchive createDeployment() {
         String urlPropName1 = InterfaceWithProvidersDefined.class.getName() + "/mp-rest/url";
         String urlPropName2 = InterfaceWithoutProvidersDefined.class.getName() + "/mp-rest/url";
+        String urlPropName3 = "theKey/mp-rest/url";
         String urlValue = getStringURL();
         String simpleName = CDIInvokeWithRegisteredProvidersTest.class.getSimpleName();
         String providersPropName = InterfaceWithoutProvidersDefined.class.getName() + "/mp-rest/providers";
@@ -80,12 +86,16 @@ public class CDIInvokeWithRegisteredProvidersTest extends WiremockArquillianTest
                                 TestParamConverterProvider.class.getName() + "," +
                                 TestReaderInterceptor.class.getName() + "," +
                                 TestWriterInterceptor.class.getName();
+        String providersConfigKeyPropName = "theKey/mp-rest/providers";
         String propsFile = String.format(urlPropName1+"="+urlValue+"%n" +
                                          urlPropName2+"="+urlValue+"%n" +
-                                         providersPropName+"="+providersValue);
+                                         urlPropName3+"="+urlValue+"%n" +
+                                         providersPropName+"="+providersValue+"%n" +
+                                         providersConfigKeyPropName+"="+providersValue);
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class, simpleName + ".jar")
             .addClasses(InterfaceWithProvidersDefined.class,
                         InterfaceWithoutProvidersDefined.class,
+                        InterfaceWithoutProvidersDefinedWithConfigKey.class,
                         InterfaceBase.class,
                         WiremockArquillianTest.class)
             .addPackage(TestClientResponseFilter.class.getPackage())
@@ -96,10 +106,7 @@ public class CDIInvokeWithRegisteredProvidersTest extends WiremockArquillianTest
             .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
-    //@BeforeTest
-    //public void resetWiremock() {
-    //    setupServer();
-    //}
+
     @Test
     public void testInvokesPostOperation_viaAnnotation() throws Exception {
         testInvokesPostOperation(clientProvidersViaAnnotation);
@@ -108,6 +115,11 @@ public class CDIInvokeWithRegisteredProvidersTest extends WiremockArquillianTest
     @Test
     public void testInvokesPostOperation_viaMPConfig() throws Exception {
         testInvokesPostOperation(clientProvidersViaMPConfig);
+    }
+
+    @Test
+    public void testInvokesPostOperation_viaMPConfigWithConfigKey() throws Exception {
+        testInvokesPostOperation(clientProvidersViaConfigKey);
     }
 
     private void testInvokesPostOperation(InterfaceBase api) throws Exception{
@@ -143,6 +155,11 @@ public class CDIInvokeWithRegisteredProvidersTest extends WiremockArquillianTest
     @Test
     public void testInvokesPutOperation_viaMPConfig() throws Exception {
         testInvokesPutOperation(clientProvidersViaMPConfig);
+    }
+
+    @Test
+    public void testInvokesPutOperation_viaMPConfigWithConfigKey() throws Exception {
+        testInvokesPutOperation(clientProvidersViaConfigKey);
     }
 
     private void testInvokesPutOperation(InterfaceBase api) throws Exception {

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/ConfigKeyForMultipleInterfacesTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/ConfigKeyForMultipleInterfacesTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.cditests;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.eclipse.microprofile.rest.client.tck.interfaces.ConfigKeyClient;
+import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApiWithConfigKey;
+import org.eclipse.microprofile.rest.client.tck.providers.ReturnWithURLRequestFilter;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Verifies that users can simplify config properties with a single config key
+ * for multiple interfaces.
+ */
+public class ConfigKeyForMultipleInterfacesTest extends Arquillian {
+
+    @Inject
+    @RestClient
+    private ConfigKeyClient client1;
+
+    @Inject
+    @RestClient
+    private SimpleGetApiWithConfigKey client2;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        String uriPropertyName = "myConfigKey/mp-rest/uri";
+        String uriValue = "http://localhost:1234/configKeyUri";
+        String simpleName = ConfigKeyTest.class.getSimpleName();
+        String providerProperty = SimpleGetApiWithConfigKey.class.getName() +
+                                  "/mp-rest/providers=" +
+                                  ReturnWithURLRequestFilter.class.getName();
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, simpleName + ".jar")
+            .addClasses(ConfigKeyClient.class,
+                        SimpleGetApiWithConfigKey.class,
+                        ReturnWithURLRequestFilter.class)
+            .addAsManifestResource(new StringAsset(
+                String.format(uriPropertyName+"="+uriValue+"%n"+providerProperty)),
+                "microprofile-config.properties")
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        return ShrinkWrap.create(WebArchive.class, simpleName + ".war")
+            .addAsLibrary(jar)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    public void testConfigKeyUsedForUri() throws Exception {
+        assertEquals(client1.get(), "GET http://localhost:1234/configKeyUri/hello");
+        assertEquals(client2.executeGet().readEntity(String.class), "GET http://localhost:1234/configKeyUri");
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/ConfigKeyTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/ConfigKeyTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.cditests;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.eclipse.microprofile.rest.client.tck.interfaces.ConfigKeyClient;
+import org.eclipse.microprofile.rest.client.tck.interfaces.ConfigKeyClient2;
+import org.eclipse.microprofile.rest.client.tck.providers.ReturnWithURLRequestFilter;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Verifies that users can simplify config properties with a config key, and that
+ * the fully-qualified classname-based property takes precedence over config keys.
+ */
+public class ConfigKeyTest extends Arquillian {
+
+    @Inject
+    @RestClient
+    private ConfigKeyClient client1;
+
+    @Inject
+    @RestClient
+    private ConfigKeyClient2 client2;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        String uriPropertyName = "myConfigKey/mp-rest/uri";
+        String uriValue = "http://localhost:1234/configKeyUri";
+        String overridePropName = ConfigKeyClient2.class.getName()+"/mp-rest/uri";
+        String overridePropValue = "http://localhost:5678/FQCNUri";
+        String simpleName = ConfigKeyTest.class.getSimpleName();
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, simpleName + ".jar")
+            .addClasses(ConfigKeyClient.class,
+                        ConfigKeyClient2.class,
+                        ReturnWithURLRequestFilter.class)
+            .addAsManifestResource(new StringAsset(
+                String.format(uriPropertyName+"="+uriValue+"%n"+
+                              overridePropName+"="+overridePropValue)),
+                "microprofile-config.properties")
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        return ShrinkWrap.create(WebArchive.class, simpleName + ".war")
+            .addAsLibrary(jar)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    public void testConfigKeyUsedForUri() throws Exception {
+        assertEquals(client1.get(), "GET http://localhost:1234/configKeyUri/hello");
+    }
+    @Test
+    public void testFullyQualifiedClassnamePropTakesPrecedenceOverConfigKey() throws Exception{
+        assertEquals(client2.get2(), "GET http://localhost:5678/FQCNUri/hello2");
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasAppScopeTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasAppScopeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Contributors to the Eclipse Foundation
+ * Copyright 2017-2019 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ package org.eclipse.microprofile.rest.client.tck.cditests;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.eclipse.microprofile.rest.client.tck.interfaces.ConfigKeyClient;
 import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -53,10 +54,12 @@ public class HasAppScopeTest extends Arquillian {
         String url = SimpleGetApi.class.getName() + "/mp-rest/url=http://localhost:8080";
         String url2 = MyAppScopedApi.class.getName() + "/mp-rest/url=http://localhost:8080";
         String scope = SimpleGetApi.class.getName() + "/mp-rest/scope=" + ApplicationScoped.class.getName();
+        String configKeyScope = "myConfigKey/mp-rest/scope=" + ApplicationScoped.class.getName();
         String simpleName = HasAppScopeTest.class.getSimpleName();
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class, simpleName + ".jar")
-            .addClasses(SimpleGetApi.class, MyAppScopedApi.class)
-            .addAsManifestResource(new StringAsset(url + "\n" + scope + "\n"+ url2), "microprofile-config.properties")
+            .addClasses(SimpleGetApi.class, MyAppScopedApi.class, ConfigKeyClient.class)
+            .addAsManifestResource(new StringAsset(url + "\n" + scope + "\n"+ url2 + "\n" + configKeyScope),
+                                   "microprofile-config.properties")
             .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
         return ShrinkWrap.create(WebArchive.class, simpleName + ".war")
             .addAsLibrary(jar)
@@ -66,6 +69,13 @@ public class HasAppScopeTest extends Arquillian {
     @Test
     public void testHasApplicationScoped() {
         Set<Bean<?>> beans = beanManager.getBeans(SimpleGetApi.class, RestClient.LITERAL);
+        Bean<?> resolved = beanManager.resolve(beans);
+        assertEquals(resolved.getScope(), ApplicationScoped.class);
+    }
+
+    @Test
+    public void testHasApplicationScopedFromConfigKey() {
+        Set<Bean<?>> beans = beanManager.getBeans(ConfigKeyClient.class, RestClient.LITERAL);
         Bean<?> resolved = beanManager.resolve(beans);
         assertEquals(resolved.getScope(), ApplicationScoped.class);
     }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasRequestScopeTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasRequestScopeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Contributors to the Eclipse Foundation
+ * Copyright 2017-2019 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ package org.eclipse.microprofile.rest.client.tck.cditests;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.eclipse.microprofile.rest.client.tck.interfaces.ConfigKeyClient;
 import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -53,10 +54,12 @@ public class HasRequestScopeTest extends Arquillian {
         String url = SimpleGetApi.class.getName() + "/mp-rest/url=http://localhost:8080";
         String url2 = MyRequestScopedApi.class.getName() + "/mp-rest/url=http://localhost:8080";
         String scope = SimpleGetApi.class.getName() + "/mp-rest/scope=" + RequestScoped.class.getName();
+        String configKeyScope = "myConfigKey/mp-rest/scope=" + RequestScoped.class.getName();
         String simpleName = HasRequestScopeTest.class.getSimpleName();
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class, simpleName + ".jar")
-            .addClasses(SimpleGetApi.class, MyRequestScopedApi.class)
-            .addAsManifestResource(new StringAsset(url + "\n" + scope + "\n" + url2), "microprofile-config.properties")
+            .addClasses(SimpleGetApi.class, MyRequestScopedApi.class, ConfigKeyClient.class)
+            .addAsManifestResource(new StringAsset(url + "\n" + scope + "\n" + url2 + "\n" + configKeyScope),
+                                                   "microprofile-config.properties")
             .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
         return ShrinkWrap.create(WebArchive.class, simpleName + ".war")
             .addAsLibrary(jar)
@@ -66,6 +69,13 @@ public class HasRequestScopeTest extends Arquillian {
     @Test
     public void testHasRequestScoped() {
         Set<Bean<?>> beans = beanManager.getBeans(SimpleGetApi.class, RestClient.LITERAL);
+        Bean<?> resolved = beanManager.resolve(beans);
+        assertEquals(resolved.getScope(), RequestScoped.class);
+    }
+
+    @Test
+    public void testHasRequestScopedFromConfigKey() {
+        Set<Bean<?>> beans = beanManager.getBeans(ConfigKeyClient.class, RestClient.LITERAL);
         Bean<?> resolved = beanManager.resolve(beans);
         assertEquals(resolved.getScope(), RequestScoped.class);
     }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasSessionScopeTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasSessionScopeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Contributors to the Eclipse Foundation
+ * Copyright 2017-2019 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ package org.eclipse.microprofile.rest.client.tck.cditests;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.eclipse.microprofile.rest.client.tck.interfaces.ConfigKeyClient;
 import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -51,10 +52,12 @@ public class HasSessionScopeTest extends Arquillian{
     public static WebArchive createDeployment() {
         String url = SimpleGetApi.class.getName()+"/mp-rest/url=http://localhost:8080";
         String scope = SimpleGetApi.class.getName()+"/mp-rest/scope="+ SessionScoped.class.getName();
+        String configKeyScope = "myConfigKey/mp-rest/scope=" + SessionScoped.class.getName();
         String simpleName = HasSessionScopeTest.class.getSimpleName();
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class, simpleName + ".jar")
-            .addClasses(SimpleGetApi.class, MySessionScopedApi.class)
-            .addAsManifestResource(new StringAsset(url+"\n"+scope), "microprofile-config.properties")
+            .addClasses(SimpleGetApi.class, MySessionScopedApi.class, ConfigKeyClient.class)
+            .addAsManifestResource(new StringAsset(url + "\n" + scope + "\n" + configKeyScope),
+                                                   "microprofile-config.properties")
             .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
         return ShrinkWrap.create(WebArchive.class, simpleName + ".war")
             .addAsLibrary(jar)
@@ -63,6 +66,13 @@ public class HasSessionScopeTest extends Arquillian{
     @Test
     public void testHasSingletonScoped() {
         Set<Bean<?>> beans = beanManager.getBeans(SimpleGetApi.class, RestClient.LITERAL);
+        Bean<?> resolved = beanManager.resolve(beans);
+        assertEquals(resolved.getScope(), SessionScoped.class);
+    }
+
+    @Test
+    public void testHasSessionScopedFromConfigKey() {
+        Set<Bean<?>> beans = beanManager.getBeans(ConfigKeyClient.class, RestClient.LITERAL);
         Bean<?> resolved = beanManager.resolve(beans);
         assertEquals(resolved.getScope(), SessionScoped.class);
     }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/ConfigKeyClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/ConfigKeyClient.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.tck.providers.ReturnWithURLRequestFilter;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/hello")
+@RegisterProvider(ReturnWithURLRequestFilter.class)
+@RegisterRestClient(configKey="myConfigKey")
+public interface ConfigKeyClient {
+    @GET
+    String get();
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/ConfigKeyClient2.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/ConfigKeyClient2.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.tck.providers.ReturnWithURLRequestFilter;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/hello2")
+@RegisterProvider(ReturnWithURLRequestFilter.class)
+@RegisterRestClient(configKey="myConfigKey")
+public interface ConfigKeyClient2 {
+    @GET
+    String get2();
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/InterfaceWithoutProvidersDefinedWithConfigKey.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/InterfaceWithoutProvidersDefinedWithConfigKey.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@Path("/")
+@Produces(MediaType.TEXT_PLAIN)
+@Consumes(MediaType.TEXT_PLAIN)
+@RegisterRestClient(configKey="theKey")
+public interface InterfaceWithoutProvidersDefinedWithConfigKey extends InterfaceBase {
+
+    @POST
+    @Override
+    Response executePost(String body);
+
+    @PUT
+    @Path("/{id}")
+    @Override
+    Response executePut(@PathParam("id") String id, String body);
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/SimpleGetApiWithConfigKey.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/SimpleGetApiWithConfigKey.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@Path("/")
+@RegisterRestClient(configKey="myConfigKey")
+public interface SimpleGetApiWithConfigKey extends SimpleGetApi {
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/timeout/TimeoutViaMPConfigWithConfigKeyTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/timeout/TimeoutViaMPConfigWithConfigKeyTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.timeout;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.eclipse.microprofile.rest.client.tck.WiremockArquillianTest;
+import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
+import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApiWithConfigKey;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+import javax.inject.Inject;
+
+import static org.testng.Assert.assertTrue;
+
+public class TimeoutViaMPConfigWithConfigKeyTest extends TimeoutTestBase {
+
+    @Inject
+    @RestClient
+    private SimpleGetApiWithConfigKey api;
+
+    @Deployment
+    public static Archive<?> createDeployment() {
+        String timeoutProps =
+                "myConfigKey/mp-rest/uri=" + UNUSED_URL + System.lineSeparator() +
+                "myConfigKey/mp-rest/connectTimeout=7000" + System.lineSeparator() +
+                "myConfigKey/mp-rest/readTimeout=7000";
+        StringAsset mpConfig = new StringAsset(timeoutProps);
+        return ShrinkWrap.create(WebArchive.class, TimeoutViaMPConfigWithConfigKeyTest.class.getSimpleName()+".war")
+            .addAsWebInfResource(mpConfig, "classes/META-INF/microprofile-config.properties")
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addClasses(SimpleGetApi.class,
+                        SimpleGetApiWithConfigKey.class,
+                        TimeoutTestBase.class,
+                        WiremockArquillianTest.class);
+    }
+
+    @Override
+    protected SimpleGetApi getClientWithReadTimeout() {
+        return api;
+    }
+
+    @Override
+    protected SimpleGetApi getClientWithConnectTimeout() {
+        return api;
+    }
+
+    @Override
+    protected void checkTimeElapsed(long elapsed) {
+        assertTrue(elapsed >= 7);
+        // allow an extra 10 seconds cushion for slower test machines
+        assertTrue(elapsed < 17);
+    }
+}


### PR DESCRIPTION
This change introduces configKeys which can be added to the `@RegisterRestClient` annotation to simplify configuration when using CDI and MP Config.

This resolves issues #115 and #168.

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>