### PR TITLE
Issue 100: Enable way to close client instances

### DIFF
--- a/spec/src/main/asciidoc/lifecycle.asciidoc
+++ b/spec/src/main/asciidoc/lifecycle.asciidoc
@@ -1,0 +1,44 @@
+//
+// Copyright (c) 2019 Contributors to the Eclipse Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+[[lifecycle]]
+== Lifecycle of Rest Clients
+
+Instances of a MicroProfile Rest Client can have two states: open and closed.
+When open, a client instance is expected to invoke RESTful services as defined by the config and annotations described throughout this document.
+When closed, a client instance is expected to throw an `IllegalStateException` when a service method is invoked.
+
+A client instance can be closed  by casting the instance to a `Closeable` or `AutoCloseable` and invoking the the `close()` method (or auto-invoked if using in a try-with-resources block).
+
+For example:
+
+[source, java]
+----
+public interface MyServiceClient {
+    @GET
+    @Path("/greet")
+    String greet();
+}
+
+...
+
+MyServiceClient client = RestClientBuilder.newBuilder()
+     .baseUri(apiUri)
+     .build(MyServiceClient.class);
+String response1 = client.greet(); // works
+((Closeable)client).close();
+String response2 = client.greet(); // throws IllegalStateException
+----

--- a/spec/src/main/asciidoc/lifecycle.asciidoc
+++ b/spec/src/main/asciidoc/lifecycle.asciidoc
@@ -21,8 +21,9 @@ Instances of a MicroProfile Rest Client can have two states: open and closed.
 When open, a client instance is expected to invoke RESTful services as defined by the config and annotations described throughout this document.
 When closed, a client instance is expected to throw an `IllegalStateException` when a service method is invoked.
 
-A client instance can be closed  by casting the instance to a `Closeable` or `AutoCloseable` and invoking the the `close()` method (or auto-invoked if using in a try-with-resources block).
+When a client instance is closed, the implementation is expected to clean up any underlying resources.
 
+A client instance can be closed  by casting the instance to a `Closeable` or `AutoCloseable` and invoking the the `close()` method (or auto-invoked if using in a try-with-resources block).
 For example:
 
 [source, java]

--- a/spec/src/main/asciidoc/microprofile-rest-client.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-rest-client.asciidoc
@@ -46,6 +46,8 @@ include::providers.asciidoc[]
 
 include::cdi.asciidoc[]
 
+include::lifecycle.asciidoc[]
+
 include::async.asciidoc[]
 
 include::integration.asciidoc[]

--- a/spec/src/main/asciidoc/release_notes.asciidoc
+++ b/spec/src/main/asciidoc/release_notes.asciidoc
@@ -23,6 +23,7 @@
 
 Changes since 1.2:
 
+- Allow client proxies to be cast to `Closeable`/`AutoCloseable`.
 - Simpler configuration using configKeys.
 - Defined `application/json` to be the default MediaType if none is specified in `@Produces`/`@Consumes`.
 

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/CloseTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/CloseTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck;
+
+import java.net.URI;
+import java.io.Closeable;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.tck.interfaces.StringClient;
+import org.eclipse.microprofile.rest.client.tck.providers.ReturnWith200RequestFilter;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class CloseTest extends Arquillian{
+    @Deployment
+    public static Archive<?> createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, CloseTest.class.getSimpleName()+".war")
+            .addClasses(ReturnWith200RequestFilter.class, StringClient.class);
+    }
+
+    @Test(expectedExceptions={IllegalStateException.class})
+    public void expectIllegalStateExceptionAfterCloseableClose() throws Exception {
+        RestClientBuilder builder = RestClientBuilder.newBuilder().register(ReturnWith200RequestFilter.class);
+        StringClient client = builder.baseUri(new URI("http://localhost/stub")).build(StringClient.class);
+        try {
+            // ensure client works correctly before closing
+            assertEquals(client.getHeaderValue("foo"), "OK");
+        }
+        catch(Throwable t) {
+            fail("Initial (unclosed) request threw unexpected exception", t);
+        }
+
+        try {
+            ((Closeable) client).close();
+        }
+        catch (Throwable t) {
+            fail("Caught unexpected exception closing client", t);
+        }
+
+        client.getHeaderValue("IllegalStateException expected");
+    }
+
+    @Test(expectedExceptions={IllegalStateException.class})
+    public void expectIllegalStateExceptionAfterAutoCloseableClose() throws Exception {
+        RestClientBuilder builder = RestClientBuilder.newBuilder().register(ReturnWith200RequestFilter.class);
+        StringClient client = builder.baseUri(new URI("http://localhost/stub")).build(StringClient.class);
+        try ( AutoCloseable ac = (AutoCloseable) client; ) {
+            assertEquals(client.getHeaderValue("foo"), "OK");
+        }
+        catch(Throwable t) {
+            fail("Initial (unclosed) request or attempt to close threw unexpected exception", t);
+        }
+
+        client.getHeaderValue("IllegalStateException expected");
+    }
+}


### PR DESCRIPTION
Enables a way to close (clean up resources, etc.) a client instance by casting the instance to a `Closeable` or `AutoCloseable` and then invoking the `close()` method.

This resolves issue #100.

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>