### PR TITLE
Update OSGi export package versions for 1.2 release

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/rest/client/annotation/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/annotation/package-info.java
@@ -33,5 +33,5 @@
  * }
  * </pre>
  */
-@org.osgi.annotation.versioning.Version("1.0.1")
+@org.osgi.annotation.versioning.Version("1.1")
 package org.eclipse.microprofile.rest.client.annotation;

--- a/api/src/main/java/org/eclipse/microprofile/rest/client/ext/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/ext/package-info.java
@@ -39,5 +39,5 @@
  * }
  * </pre>
  */
-@org.osgi.annotation.versioning.Version("1.0.1")
+@org.osgi.annotation.versioning.Version("1.1")
 package org.eclipse.microprofile.rest.client.ext;

--- a/api/src/main/java/org/eclipse/microprofile/rest/client/inject/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/inject/package-info.java
@@ -44,5 +44,5 @@
  * }
  * </pre>
  */
-@org.osgi.annotation.versioning.Version("1.0.1")
+@org.osgi.annotation.versioning.Version("1.1")
 package org.eclipse.microprofile.rest.client.inject;

--- a/api/src/main/java/org/eclipse/microprofile/rest/client/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/package-info.java
@@ -37,5 +37,5 @@
  * </pre>
  * @since 1.0
  */
-@org.osgi.annotation.versioning.Version("1.1")
+@org.osgi.annotation.versioning.Version("1.2")
 package org.eclipse.microprofile.rest.client;

--- a/api/src/main/java/org/eclipse/microprofile/rest/client/spi/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/spi/package-info.java
@@ -23,5 +23,5 @@
  * provide additional functionality for MP Rest Clients.
  *
  */
-@org.osgi.annotation.versioning.Version("1.0.1")
+@org.osgi.annotation.versioning.Version("1.1")
 package org.eclipse.microprofile.rest.client.spi;


### PR DESCRIPTION
Issue #177 correctly identified that we did not update the OSGi package versions prior to the 1.2 release.  I've taken a crack at updating them now (I think we made minor updates to every package), and after this has been reviewed, I'll plan to back port this back to the 1.2-service branch, and possibly cut a new micro release.

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>