### PR TITLE
Use source 8 for javadocs

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -69,6 +69,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                </configuration> 
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
This change avoid an issue documented [here](https://bugs.openjdk.java.net/browse/JDK-8212233) where the Maven Javadoc Plugin will fail when building using Java 11.

Thanks to James Carman who suggested it in gitter.

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>