### PR TITLE
Fixes #186

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/rest/client/ext/AsyncInvocationInterceptor.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/ext/AsyncInvocationInterceptor.java
@@ -25,7 +25,7 @@ package org.eclipse.microprofile.rest.client.ext;
  * The MP Rest Client implementation runtime will invoke the <code>pre</code>
  * method on the main thread prior to returning execution back to the calling
  * method of the client interface.  The runtime will invoke the
- * <code>prepareContext</code> method on the secondary thread before the client
+ * <code>prepareContext</code> method on the invocation thread before the client
  * request is sent.  The <code>prepareContext</code> method should always be
  * invoked before the <code>applyContext</code> method is invoked, but due to
  * the nature of multithreading, it is possible that <code>applyContext</code>
@@ -36,6 +36,10 @@ package org.eclipse.microprofile.rest.client.ext;
  * Note that the order in which instances of the
  * <code>AsyncInvocationInterceptor</code> are invoked are determined by the
  * priority of the <code>AsyncInvocationInterceptorFactory</code> provider.
+ *
+ * Note that the main and secondary threads handling the request/response may
+ * be the same. It depends on how the implementation chooses to implement the
+ * asynchronous handling.
  *
  * @since 1.1
  */

--- a/spec/src/main/asciidoc/async.asciidoc
+++ b/spec/src/main/asciidoc/async.asciidoc
@@ -17,7 +17,7 @@
 [[restasync]]
 == MicroProfile Rest Client Asynchronous Support
 
-It is possible for Rest Client interface methods to be declared asynchronous.  This allows the thread invoking the interface method to proceed while the RESTful request occurs on another thread.
+It is possible for Rest Client interface methods to be declared asynchronous.  This allows the implementation to utilize non blocking behavior in handling the request.
 
 === Asynchronous Methods
 
@@ -41,22 +41,22 @@ public interface MyAsyncClient {
 === ExecutorService
 
 By default, the MicroProfile Rest Client implementation can determine how to implement the asynchronous request.
-The primary requirement for the implementation is that the response from the remote server should be handled on a different thread than the thread invoking the asynchronous method.
-Providers on the outbound client request chain (such as providers of type `ClientRequestFilter`, `MessageBodyWriter`, `WriterInterceptor`, etc.) may be executed on either thread.
+The primary requirement for the implementation is that the response from the remote server should be handled asynchronously from the invoking method.
 
 Callers may override the default implementation by providing their own `ExecutorService` via the `RestClientBuilder.executorService(ExecutorService)` method.
 The implementation must use the `ExecutorService` provided for all asynchronous methods on any interface built via the `RestClientBuilder`.
 
 === AsyncInvocationInterceptors
 
-There may be cases where it is necessary for client application code or runtime components to be notified when control of the client request/response has flowed from one thread to another.
+There may be cases where it is necessary for client application code or runtime components to be notified when control of the client request/response is being invoked asynchronously.
 This can be accomplished by registering an implementation of the AsyncInvocationInterceptorFactory provider interface.
-MP Rest Client implementations must invoke the `newInterceptor` method of each registered factory provider prior to switching thread of execution on async method requests.
+MP Rest Client implementations must invoke the `newInterceptor` method of each registered factory provider prior to commencing execution on async method requests.
 That method will return an instance of `AsyncInvocationInterceptor` - the MP Rest Client implementation must then invoke the `prepareContext` method while still executing on the thread that invoked the async method.
-After swapping threads, but before invoking further providers or returning control back to the async method caller, the MP Rest Client implementation must invoke the `applyContext` method on the new async thread that will complete the request/response.
-The implementation must then invoke all inbound response providers (filters, interceptors, MessageBodyReaders, etc.) and then must invoke the `removeContext` method on the `AsyncInvocationInterceptor`.  This allows the provider to remove any contexts from the thread before returning control back to the user.
+After commencing asynchronous processing, but before invoking further providers or returning control back to the async method caller, the MP Rest Client implementation must invoke the `applyContext` method.
+The implementation must then invoke all inbound response providers (filters, interceptors, MessageBodyReaders, etc.) and then must invoke the `removeContext` method on the `AsyncInvocationInterceptor`.
+This allows the provider to remove any contexts before returning control back to the user.
 
-The following example shows how the `AsyncInvocationInterceptorFactory` provider and associated `AsyncInvocationInterceptor` interface could be used to propagate a `ThreadLocal` value from the originating thread to async thread:
+The following example shows how the `AsyncInvocationInterceptorFactory` provider and associated `AsyncInvocationInterceptor` interface could be used to propagate a `ThreadLocal` value:
 [source, java]
 ----
 public class MyFactory implements AsyncInvocationInterceptorFactory {
@@ -68,7 +68,6 @@ public class MyFactory implements AsyncInvocationInterceptorFactory {
 
 public class MyInterceptor implements AsyncInvocationInterceptor {
     // This field is temporary storage to facilitate copying a ThreadLocal value
-    // from the originating thread to the new async thread.
     private volatile String someValue;
 
     public void prepareContext() {

--- a/spec/src/main/asciidoc/microprofile-rest-client.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-rest-client.asciidoc
@@ -18,8 +18,8 @@
 //
 
 = Rest Client for MicroProfile
-:authors: John D. Ament, Andy McCright
-:email: john.d.ament@gmail.com, j.andrew.mccright@gmail.com
+:authors: John D. Ament, Andy McCright, Ken Finnigan
+:email: john.d.ament@gmail.com, j.andrew.mccright@gmail.com, ken@kenfinnigan.me
 :version-label!:
 :sectanchors:
 :doctype: book

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/asynctests/AsyncMethodTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/asynctests/AsyncMethodTest.java
@@ -80,7 +80,8 @@ public class AsyncMethodTest extends WiremockArquillianTest{
      *
      * @throws Exception - indicates test failure
      */
-    @Test
+    // Commented out for now. May revisit in future an alternative way to test asynchronous handling.
+//    @Test
     public void testInterfaceMethodWithCompletionStageResponseReturnIsInvokedAsynchronously() throws Exception{
         final String expectedBody = "Hello, Async Client!";
         stubFor(get(urlEqualTo("/"))


### PR DESCRIPTION
 - Remove text that specifically mentions threads that will handle the request/response
 - Disable TCK test that verifies Thread ID when using asynchronous processing

Signed-off-by: Ken Finnigan <ken@kenfinnigan.me>