### PR TITLE
Use WEB-INF/classes/META-INF for test app resources

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ssl/SslHostnameVerifierTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ssl/SslHostnameVerifierTest.java
@@ -55,9 +55,10 @@ public class SslHostnameVerifierTest extends AbstractSslTest {
                 HttpsServer.class,
                 AbstractSslTest.class,
                 ConfigurableHostnameVerifier.class)
-            .addAsManifestResource(new StringAsset(config), "microprofile-config.properties")
-            .addAsManifestResource(
-                new ClassLoaderAsset("ssl/" + clientWrongHostnameTruststoreFromClasspath), clientWrongHostnameTruststoreFromClasspath
+            .addAsWebInfResource(new StringAsset(config), "classes/META-INF/microprofile-config.properties")
+            .addAsWebInfResource(
+                new ClassLoaderAsset("ssl/" + clientWrongHostnameTruststoreFromClasspath),
+                "classes/META-INF/" + clientWrongHostnameTruststoreFromClasspath
             )
             .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
 

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ssl/SslMutualTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ssl/SslMutualTest.java
@@ -92,8 +92,8 @@ public class SslMutualTest extends AbstractSslTest {
             .addClasses(JsonPClient.class, ClientWithTruststore.class, ClientWithNonMatchingStore.class,
                 ClientWithKeystoreAndTruststore.class, ClientWithKeystoreFromClasspathAndTruststore.class,
                 HttpsServer.class, AbstractSslTest.class)
-            .addAsManifestResource(new StringAsset(config), "microprofile-config.properties")
-            .addAsManifestResource(new ClassLoaderAsset("ssl/" + clientKeystoreFromClasspath), clientKeystoreFromClasspath)
+            .addAsWebInfResource(new StringAsset(config), "classes/META-INF/microprofile-config.properties")
+            .addAsWebInfResource(new ClassLoaderAsset("ssl/" + clientKeystoreFromClasspath), "classes/META-INF/" + clientKeystoreFromClasspath)
             .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
 
         return webArchive;

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ssl/SslTrustStoreTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ssl/SslTrustStoreTest.java
@@ -75,8 +75,8 @@ public class SslTrustStoreTest extends AbstractSslTest {
                 JsonPClientWithTruststoreFromClasspath.class,
                 HttpsServer.class,
                 AbstractSslTest.class)
-            .addAsManifestResource(new StringAsset(config), "microprofile-config.properties")
-            .addAsManifestResource(new ClassLoaderAsset("ssl/" + clientTruststoreFromClasspath), clientTruststoreFromClasspath)
+            .addAsWebInfResource(new StringAsset(config), "classes/META-INF/microprofile-config.properties")
+            .addAsWebInfResource(new ClassLoaderAsset("ssl/" + clientTruststoreFromClasspath), "classes/META-INF/" + clientTruststoreFromClasspath)
             .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
 
         return webArchive;


### PR DESCRIPTION
This resolves an issue in PR #187 for some implementations by ensuring that test web app resources are packaged in the WAR's WEB-INF/classes/META-INF directory instead of the WAR's META-INF directory.  This brings consistency with the MP Config TCKs and ensures that the resources are loadable from the WAR's classloader.

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>