### PR TITLE
Clarify interfaces can extend Closeable/AutoCloseable

### DIFF
--- a/spec/src/main/asciidoc/lifecycle.asciidoc
+++ b/spec/src/main/asciidoc/lifecycle.asciidoc
@@ -23,7 +23,7 @@ When closed, a client instance is expected to throw an `IllegalStateException` w
 
 When a client instance is closed, the implementation is expected to clean up any underlying resources.
 
-A client instance can be closed  by casting the instance to a `Closeable` or `AutoCloseable` and invoking the the `close()` method (or auto-invoked if using in a try-with-resources block).
+A client instance can be closed by casting the instance to a `Closeable` or `AutoCloseable` and invoking the the `close()` method (or auto-invoked if using in a try-with-resources block).
 For example:
 
 [source, java]
@@ -41,5 +41,29 @@ MyServiceClient client = RestClientBuilder.newBuilder()
      .build(MyServiceClient.class);
 String response1 = client.greet(); // works
 ((Closeable)client).close();
+String response2 = client.greet(); // throws IllegalStateException
+----
+
+Likewise, if the client interface extends `java.lang.AutoCloseable` or `java.io.Closeable`, the client can be closed by simply calling the inherited `close()` method.
+For example:
+
+[source, java]
+----
+public interface MyServiceClient extends AutoCloseable {
+    @GET
+    @Path("/greet")
+    String greet();
+}
+
+...
+
+MyServiceClient client = RestClientBuilder.newBuilder()
+     .baseUri(apiUri)
+     .build(MyServiceClient.class);
+String response1;
+try (MyServiceClient c = client) {
+    response1 = c.greet(); // works
+} // client is auto-closed
+
 String response2 = client.greet(); // throws IllegalStateException
 ----

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/AutoCloseableClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/AutoCloseableClient.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+public interface AutoCloseableClient extends AutoCloseable {
+
+    @GET
+    @Path("/somePath")
+    String executeGet();
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/CloseableClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/CloseableClient.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+import java.io.Closeable;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+public interface CloseableClient extends Closeable {
+
+    @GET
+    @Path("/somePath")
+    String executeGet();
+}


### PR DESCRIPTION
This addresses issue #192 that it is possible for the client interface to extend `Closeable` or `AutoCloseable` and then avoid needing to cast the client interface in order to close.

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>