### PR TITLE
Use sslContextFactory.setEndpointIdentificationAlgorithm(null) in SSL tests

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ssl/HttpsServer.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ssl/HttpsServer.java
@@ -57,6 +57,7 @@ public class HttpsServer {
         sslContextFactory.setTrustStorePath(keystore);
         sslContextFactory.setTrustStorePassword(keyStorePassword);
         sslContextFactory.setNeedClientAuth(true);
+        sslContextFactory.setEndpointIdentificationAlgorithm(null);
         return this;
     }
 


### PR DESCRIPTION
Resolves issue #194.

I plan to back port this to 1.3.X-service to be part of the 1.3.1 release.

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>