### PR TITLE
Make JSON-B optional to keep EE7 compatibility

### DIFF
--- a/spec/src/main/asciidoc/providers.asciidoc
+++ b/spec/src/main/asciidoc/providers.asciidoc
@@ -110,7 +110,7 @@ Implementations may provide any number of providers registered automatically, bu
 
 === JSON-P and JSON-B Providers
 
-Implementations of the MicroProfile Rest Client should behave similar to JAX-RS implementations with regard to built-in JSON-P and JSON-B providers. Implementations must provide built-in JSON-P and JSON-B entity providers. Note that the JSON-B provider should take precedence over the JSON-P provider unless the client interface method's entity parameter or return type is a JSON-P object type (`javax.json.JsonObject`, `javax.json.JsonArray`, etc.).
+Implementations of the MicroProfile Rest Client should behave similar to JAX-RS implementations with regard to built-in JSON-P and JSON-B providers. Implementations must provide a built-in JSON-P entity provider. If the implementation supports JSON-B, then it must also provide a built-in JSON-B entity provider. Note that the JSON-B provider should take precedence over the JSON-P provider unless the client interface method's entity parameter or return type is a JSON-P object type (`javax.json.JsonObject`, `javax.json.JsonArray`, etc.).
 
 When an interface is registered that contains:
 

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeWithJsonBProviderTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeWithJsonBProviderTest.java
@@ -55,6 +55,15 @@ public class InvokeWithJsonBProviderTest extends WiremockArquillianTest{
             .addAsWebInfResource(mpConfig, "classes/META-INF/microprofile-config.properties");
     }
 
+    private static void assumeJsonbApiExists() throws SkipException {
+        try {
+            Class.forName("javax.json.bind.annotation.JsonbProperty");
+        }
+        catch (Throwable t) {
+            throw new SkipException("Skipping since JSON-B APIs were not found.");
+        }
+    }
+
     @RestClient
     @Inject
     private JsonBClient cdiJsonBClient;
@@ -70,6 +79,7 @@ public class InvokeWithJsonBProviderTest extends WiremockArquillianTest{
 
     @Test
     public void testGetExecutesForBothClients() throws Exception {
+        assumeJsonbApiExists();
         testGet(builtJsonBClient, BUILT);
         testGet(cdiJsonBClient, CDI);
     }


### PR DESCRIPTION
Effectively reverts the changes in PR #172 that made JSON-B a hard
dependency (rather than an optional dependency).  Making it a hard
dependency would be a breaking change, and should not be made prior to a
2.0 release.

I will plan to back port this to 1.3.X-service.

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>