### PR TITLE
[Issue 204] Explicitly use PKCS12 store type for TCK tests

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ssl/AbstractSslTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ssl/AbstractSslTest.java
@@ -70,7 +70,7 @@ public abstract class AbstractSslTest extends Arquillian {
 
 
     public static KeyStore getKeyStore(File keystoreFile) throws Exception {
-        KeyStore keystore = KeyStore.getInstance("JKS");
+        KeyStore keystore = KeyStore.getInstance("pkcs12");
         try (FileInputStream input = new FileInputStream(keystoreFile)) {
             keystore.load(input, PASSWORD.toCharArray());
         }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ssl/HttpsServer.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ssl/HttpsServer.java
@@ -50,12 +50,14 @@ public class HttpsServer {
     public HttpsServer keyStore(String keystore, String keyStorePassword) {
         sslContextFactory.setKeyStorePath(keystore);
         sslContextFactory.setKeyStorePassword(keyStorePassword);
+        sslContextFactory.setKeyStoreType("pkcs12");
         return this;
     }
 
     public HttpsServer trustStore(String keystore, String keyStorePassword) {
         sslContextFactory.setTrustStorePath(keystore);
         sslContextFactory.setTrustStorePassword(keyStorePassword);
+        sslContextFactory.setTrustStoreType("pkcs12");
         sslContextFactory.setNeedClientAuth(true);
         sslContextFactory.setEndpointIdentificationAlgorithm(null);
         return this;

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ssl/SslContextTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ssl/SslContextTest.java
@@ -49,7 +49,7 @@ public class SslContextTest extends AbstractSslTest {
     public void shouldSucceedMutualSslWithValidSslContext() throws Exception {
         SSLContext sslContext = SSLContextBuilder.create()
             .loadKeyMaterial(getKeyStore(clientKeystore), PASSWORD.toCharArray())
-            .loadTrustMaterial(clientTruststore, PASSWORD.toCharArray())
+            .loadTrustMaterial(getKeyStore(clientTruststore), null)
             .build();
         RestClientBuilder.newBuilder()
             .baseUri(BASE_URI)

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ssl/SslHostnameVerifierTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ssl/SslHostnameVerifierTest.java
@@ -45,6 +45,7 @@ public class SslHostnameVerifierTest extends AbstractSslTest {
             configLine(JsonPClient.class, "uri", BASE_URI_STRING) +
             configLine(JsonPClient.class, "hostnameVerifier", ConfigurableHostnameVerifier.class.getCanonicalName()) +
             configLine(JsonPClient.class, "trustStore", "classpath:/META-INF/" + clientWrongHostnameTruststoreFromClasspath) +
+            configLine(JsonPClient.class, "trustStoreType", "pkcs12") +
             configLine(JsonPClient.class, "trustStorePassword", PASSWORD);
         // @formatter:on
 

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ssl/SslMutualTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ssl/SslMutualTest.java
@@ -67,24 +67,31 @@ public class SslMutualTest extends AbstractSslTest {
         String config =
             configLine(JsonPClient.class, "uri", BASE_URI_STRING) +
             configLine(ClientWithTruststore.class, "trustStore", filePath(clientTruststore)) +
+            configLine(ClientWithTruststore.class, "trustStoreType", "pkcs12") +
             configLine(ClientWithTruststore.class, "trustStorePassword", PASSWORD) +
             configLine(ClientWithTruststore.class, "uri", BASE_URI_STRING) +
 
             configLine(ClientWithKeystoreAndTruststore.class, "trustStore", filePath(clientTruststore)) +
+            configLine(ClientWithKeystoreAndTruststore.class, "trustStoreType", "pkcs12") +
             configLine(ClientWithKeystoreAndTruststore.class, "trustStorePassword", PASSWORD) +
             configLine(ClientWithKeystoreAndTruststore.class, "keyStore", filePath(clientKeystore)) +
+            configLine(ClientWithKeystoreAndTruststore.class, "keyStoreType", "pkcs12") +
             configLine(ClientWithKeystoreAndTruststore.class, "keyStorePassword", PASSWORD) +
             configLine(ClientWithKeystoreAndTruststore.class, "uri", BASE_URI_STRING) +
 
             configLine(ClientWithKeystoreFromClasspathAndTruststore.class, "trustStore", filePath(clientTruststore)) +
             configLine(ClientWithKeystoreFromClasspathAndTruststore.class, "trustStorePassword", PASSWORD) +
+            configLine(ClientWithKeystoreFromClasspathAndTruststore.class, "trustStoreType", "pkcs12") +
             configLine(ClientWithKeystoreFromClasspathAndTruststore.class, "keyStore", "classpath:/META-INF/" + clientKeystoreFromClasspath) +
+            configLine(ClientWithKeystoreFromClasspathAndTruststore.class, "keyStoreType", "pkcs12") +
             configLine(ClientWithKeystoreFromClasspathAndTruststore.class, "keyStorePassword", PASSWORD) +
             configLine(ClientWithKeystoreFromClasspathAndTruststore.class, "uri", BASE_URI_STRING) +
 
             configLine(ClientWithNonMatchingStore.class, "trustStore", filePath(clientTruststore)) +
+            configLine(ClientWithNonMatchingStore.class, "trustStoreType", "pkcs12") +
             configLine(ClientWithNonMatchingStore.class, "trustStorePassword", PASSWORD) +
             configLine(ClientWithNonMatchingStore.class, "keyStore", filePath(serverKeystore)) +
+            configLine(ClientWithNonMatchingStore.class, "keyStoreType", "pkcs12") +
             configLine(ClientWithNonMatchingStore.class, "keyStorePassword", PASSWORD) +
             configLine(ClientWithNonMatchingStore.class, "uri", BASE_URI_STRING);
         // @formatter:on

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ssl/SslTrustStoreTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ssl/SslTrustStoreTest.java
@@ -58,12 +58,15 @@ public class SslTrustStoreTest extends AbstractSslTest {
         String config =
             configLine(JsonPClient.class, "uri", BASE_URI_STRING) +
             configLine(ClientWithTruststore.class, "trustStore", filePath(clientTruststore)) +
+            configLine(ClientWithTruststore.class, "trustStoreType", "pkcs12") +
             configLine(ClientWithTruststore.class, "trustStorePassword", PASSWORD) +
             configLine(ClientWithTruststore.class, "uri", BASE_URI_STRING) +
             configLine(JsonPClientWithTruststoreFromClasspath.class, "trustStore", "classpath:/META-INF/" + clientTruststoreFromClasspath) +
+            configLine(JsonPClientWithTruststoreFromClasspath.class, "trustStoreType", "pkcs12") +
             configLine(JsonPClientWithTruststoreFromClasspath.class, "trustStorePassword", PASSWORD) +
             configLine(JsonPClientWithTruststoreFromClasspath.class, "uri", BASE_URI_STRING) +
             configLine(ClientWithNonMatchingStore.class, "trustStore", filePath(anotherTruststore)) +
+            configLine(ClientWithNonMatchingStore.class, "trustStoreType", "pkcs12") +
             configLine(ClientWithNonMatchingStore.class, "trustStorePassword", PASSWORD) +
             configLine(ClientWithNonMatchingStore.class, "uri", BASE_URI_STRING);
         // @formatter:on


### PR DESCRIPTION
The SSL TCK tests use PKCS12 key/trust store types, but the tests themselves either specify JKS or rely on the default store type (for JDK 8, that is JKS - for 9+, that is PKCS12). Most JDKs can handle PKCS12 types, even when the code specifies JKS, but IBM JDK 8 cannot.

This change explicitly sets the store type in JVM system properties, the Jetty test code and MP Config properties for the test application.

This PR is still a work in progress - when finished, it should resolve issue #204.

This PR should be merged to 1.3.X-service and master.

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>