### PR TITLE
[Issue 218] Pass certificate directory to test via classpath

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ssl/AbstractSslTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ssl/AbstractSslTest.java
@@ -95,7 +95,7 @@ public abstract class AbstractSslTest extends Arquillian {
 
         startServer(serverInitializer);
 
-        webArchive.addAsManifestResource(new StringAsset(certificatesDirectory.toAbsolutePath().toString()), CERT_LOCATION_FILE);
+        webArchive.addAsResource(new StringAsset(certificatesDirectory.toAbsolutePath().toString()), "META-INF/" + CERT_LOCATION_FILE);
     }
 
     static void initializeCertificateLocations() {


### PR DESCRIPTION
This is fix for #218 on service branch. We'd welcome a release of TCK with this fix soon, as we'd like to be compatible with our next release.