### PR TITLE
Update dependencies to use Jakarta EE 8 APIs

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,7 +21,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.rest.client</groupId>
         <artifactId>microprofile-rest-client-parent</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>microprofile-rest-client-api</artifactId>
@@ -29,22 +29,22 @@
     <description>Typesafe Rest Client APIs for MicroProfile :: API</description>
     <dependencies>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-            <version>1</version>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <version>1.0</version>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
@@ -147,5 +147,4 @@
             </build>
         </profile>
     </profiles>
-
 </project>

--- a/api/src/main/java/org/eclipse/microprofile/rest/client/ext/DefaultClientHeadersFactoryImpl.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/ext/DefaultClientHeadersFactoryImpl.java
@@ -46,7 +46,6 @@ public class DefaultClientHeadersFactoryImpl implements ClientHeadersFactory {
     private final static Logger LOG = Logger.getLogger(CLASS_NAME);
 
     private static Optional<Config> config() {
-        Config c;
         try {
             return Optional.ofNullable(ConfigProvider.getConfig());
         }
@@ -71,7 +70,7 @@ public class DefaultClientHeadersFactoryImpl implements ClientHeadersFactory {
         if (LOG.isLoggable(Level.FINER)) {
             LOG.entering(CLASS_NAME, "update", new Object[]{incomingHeaders, clientOutgoingHeaders});
         }
-        MultivaluedMap propagatedHeaders = new MultivaluedHashMap();
+        MultivaluedMap<String, String> propagatedHeaders = new MultivaluedHashMap<>();
         Optional<String> propagateHeaderString = getHeadersProperty();
         if (propagateHeaderString.isPresent()) {
             Arrays.stream(propagateHeaderString.get().split(","))

--- a/api/src/test/java/org/eclipse/microprofile/rest/client/ext/MockConfigProviderResolver.java
+++ b/api/src/test/java/org/eclipse/microprofile/rest/client/ext/MockConfigProviderResolver.java
@@ -32,6 +32,7 @@ public class MockConfigProviderResolver extends ConfigProviderResolver {
     public Config getConfig() {
         return new Config(){
             @Override
+            @SuppressWarnings("unchecked")
             public <T> T getValue(String propertyName, Class<T> propertyType) {
                 Map<String, String> props = getConfigSources().iterator().next().getProperties();
                 if (!props.containsKey(propertyName)) {

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>org.eclipse.microprofile.rest.client</groupId>
     <artifactId>microprofile-rest-client-parent</artifactId>
-    <version>1.4-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>MicroProfile Rest Client</name>
     <description>Typesafe Rest Client APIs for MicroProfile</description>
@@ -90,27 +90,27 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>javax.enterprise</groupId>
-                <artifactId>cdi-api</artifactId>
-                <version>1.2</version>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
+                <version>2.0.2</version>
                 <scope>provided</scope>
                 <exclusions>
                     <exclusion>
-                        <groupId>javax.el</groupId>
-                        <artifactId>javax.el-api</artifactId>
+                        <groupId>jakarta.el</groupId>
+                        <artifactId>jakarta.el-api</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>javax.ws.rs</groupId>
-                <artifactId>javax.ws.rs-api</artifactId>
-                <version>2.0.1</version>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
+                <version>2.1.6</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>javax.annotation</groupId>
-                <artifactId>javax.annotation-api</artifactId>
-                <version>1.2</version>
+                <groupId>jakarta.annotation</groupId>
+                <artifactId>jakarta.annotation-api</artifactId>
+                <version>1.3.5</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -20,7 +20,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.rest.client</groupId>
         <artifactId>microprofile-rest-client-parent</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>microprofile-rest-client-spec</artifactId>
@@ -94,6 +94,4 @@
             </plugin>
         </plugins>
     </build>
-
-
 </project>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -21,7 +21,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.rest.client</groupId>
         <artifactId>microprofile-rest-client-parent</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>microprofile-rest-client-tck</artifactId>
@@ -40,8 +40,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
 
         <dependency>
@@ -60,15 +60,15 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
-            <version>1.0</version>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+            <version>1.1.6</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.json.bind</groupId>
-            <artifactId>javax.json.bind-api</artifactId>
-            <version>1.0</version>
+            <groupId>jakarta.json.bind</groupId>
+            <artifactId>jakarta.json.bind-api</artifactId>
+            <version>1.0.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -86,8 +86,8 @@
             <version>2.10.1</version>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
     </dependencies>
 
@@ -111,5 +111,4 @@
             </build>
         </profile>
     </profiles>
-
 </project>

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/AdditionalRegistrationTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/AdditionalRegistrationTest.java
@@ -77,7 +77,7 @@ public class AdditionalRegistrationTest extends Arquillian{
     @Test
     public void shouldRegisterAMultiTypedProviderInstance() {
         MultiTypedProvider provider = new MultiTypedProvider();
-        Class[] providerTypes = {ClientRequestFilter.class, ClientResponseFilter.class,
+        Class<?>[] providerTypes = {ClientRequestFilter.class, ClientResponseFilter.class,
             MessageBodyReader.class, MessageBodyWriter.class, ReaderInterceptor.class, WriterInterceptor.class,
             ResponseExceptionMapper.class, ParamConverterProvider.class};
         RestClientBuilder builder = RestClientBuilder.newBuilder().register(provider, providerTypes);
@@ -126,7 +126,7 @@ public class AdditionalRegistrationTest extends Arquillian{
 
     @Test
     public void shouldRegisterAMultiTypedProviderClass() {
-        Class[] providerTypes = {ClientRequestFilter.class, ClientResponseFilter.class,
+        Class<?>[] providerTypes = {ClientRequestFilter.class, ClientResponseFilter.class,
             MessageBodyReader.class, MessageBodyWriter.class, ReaderInterceptor.class, WriterInterceptor.class,
             ResponseExceptionMapper.class, ParamConverterProvider.class};
         RestClientBuilder builder = RestClientBuilder.newBuilder().register(MultiTypedProvider.class, providerTypes);

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/FeatureRegistrationTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/FeatureRegistrationTest.java
@@ -31,7 +31,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
 import javax.inject.Inject;
-import static org.eclipse.microprofile.rest.client.tck.WiremockArquillianTest.getStringURL;
 
 import static org.testng.Assert.assertTrue;
 

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/MultiTypedProvider.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/MultiTypedProvider.java
@@ -42,43 +42,44 @@ import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
-public class MultiTypedProvider implements ClientRequestFilter, ClientResponseFilter, MessageBodyReader, MessageBodyWriter,
-    ReaderInterceptor, WriterInterceptor, ResponseExceptionMapper, ParamConverterProvider{
+public class MultiTypedProvider implements ClientRequestFilter, ClientResponseFilter, MessageBodyReader<Object>,
+    MessageBodyWriter<Object>, ReaderInterceptor, WriterInterceptor, ResponseExceptionMapper<Throwable>,
+    ParamConverterProvider{
+
     @Override
     public void filter(ClientRequestContext requestContext) throws IOException {
-
     }
 
     @Override
     public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) throws IOException {
-
     }
 
     @Override
-    public boolean isReadable(Class type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+    public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
         return false;
     }
 
     @Override
-    public Object readFrom(Class type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap httpHeaders,
-                           InputStream entityStream) throws IOException, WebApplicationException {
+    public Object readFrom(Class<Object> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+        MultivaluedMap<String, String> httpHeaders, InputStream entityStream)
+        throws IOException, WebApplicationException {
         return null;
     }
 
     @Override
-    public boolean isWriteable(Class type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
         return false;
     }
 
     @Override
-    public long getSize(Object o, Class type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+    public long getSize(Object o, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
         return 0;
     }
 
     @Override
-    public void writeTo(Object o, Class type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap httpHeaders,
-                        OutputStream entityStream) throws IOException, WebApplicationException {
-
+    public void writeTo(Object t, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+            MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream)
+            throws IOException, WebApplicationException {
     }
 
     @Override
@@ -93,7 +94,6 @@ public class MultiTypedProvider implements ClientRequestFilter, ClientResponseFi
 
     @Override
     public void aroundWriteTo(WriterInterceptorContext context) throws IOException, WebApplicationException {
-
     }
 
     @Override

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TestParamConverterProvider.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TestParamConverterProvider.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Type;
 
 public class TestParamConverterProvider implements ParamConverterProvider {
     @Override
+    @SuppressWarnings("unchecked")
     public <T> ParamConverter<T> getConverter(Class<T> aClass, Type type, Annotation[] annotations) {
         if(String.class.isAssignableFrom(aClass)) {
             return (ParamConverter<T>) new TestParamConverter();


### PR DESCRIPTION
This pull request resolves issue #231.

Because MP Rest Client version 1.3 previously compiled against some Java EE 7 technologies (JAX-RS 2.0 and CDI 1.2, etc.) and now are compiling against Java EE 8 / Jakarta EE 8, this requires a major version update, so the version now shows 2.0-SNAPSHOT instead of 1.4-SNAPSHOT.

This change also resolves some Java compiler warnings.