### PR TITLE
Initialize 1.4.x branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ test-output
 *.iml
 *.iwl
 *.ipr
+.vscode/
+api/.DS_Store

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,7 +21,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.rest.client</groupId>
         <artifactId>microprofile-rest-client-parent</artifactId>
-        <version>1.3.5-SNAPSHOT</version>
+        <version>1.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>microprofile-rest-client-api</artifactId>

--- a/api/src/main/java/org/eclipse/microprofile/rest/client/ext/DefaultClientHeadersFactoryImpl.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/ext/DefaultClientHeadersFactoryImpl.java
@@ -46,7 +46,6 @@ public class DefaultClientHeadersFactoryImpl implements ClientHeadersFactory {
     private final static Logger LOG = Logger.getLogger(CLASS_NAME);
 
     private static Optional<Config> config() {
-        Config c;
         try {
             return Optional.ofNullable(ConfigProvider.getConfig());
         }
@@ -71,7 +70,7 @@ public class DefaultClientHeadersFactoryImpl implements ClientHeadersFactory {
         if (LOG.isLoggable(Level.FINER)) {
             LOG.entering(CLASS_NAME, "update", new Object[]{incomingHeaders, clientOutgoingHeaders});
         }
-        MultivaluedMap propagatedHeaders = new MultivaluedHashMap();
+        MultivaluedMap<String, String> propagatedHeaders = new MultivaluedHashMap<>();
         Optional<String> propagateHeaderString = getHeadersProperty();
         if (propagateHeaderString.isPresent()) {
             Arrays.stream(propagateHeaderString.get().split(","))

--- a/api/src/main/java/org/eclipse/microprofile/rest/client/inject/RestClient.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/inject/RestClient.java
@@ -19,8 +19,10 @@ package org.eclipse.microprofile.rest.client.inject;
 import javax.enterprise.util.AnnotationLiteral;
 import javax.inject.Qualifier;
 import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * Use the RestClient qualifier on an injection to point to indicate that this injection point is meant to use an instance
@@ -34,6 +36,7 @@ import java.lang.annotation.RetentionPolicy;
  *
  * This will cause the injection point to be satisfied by the MicroProfile Rest Client runtime.
  */
+@Target({ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.METHOD})
 @Qualifier
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/org/eclipse/microprofile/rest/client/spi/RestClientBuilderResolver.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/spi/RestClientBuilderResolver.java
@@ -1,6 +1,6 @@
 /*
  *******************************************************************************
- * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -98,26 +98,19 @@ public abstract class RestClientBuilderResolver {
             return null;
         }
 
-        // start from the root CL and go back down to the TCCL
-        PrivilegedAction<ClassLoader> action = () -> cl.getParent();
-        RestClientBuilderResolver resolver = loadSpi(AccessController.doPrivileged(action));
+        RestClientBuilderResolver instance = null;
 
-        if (resolver == null) {
-            ServiceLoader<RestClientBuilderResolver> sl = ServiceLoader.load(
-                    RestClientBuilderResolver.class, cl);
-            for (RestClientBuilderResolver spi : sl) {
-                if (resolver != null) {
-                    throw new IllegalStateException(
-                            "Multiple RestClientBuilderResolver implementations found: "
-                            + spi.getClass().getName() + " and "
-                            + resolver.getClass().getName());
-                }
-                else {
-                    resolver = spi;
-                }
+        ServiceLoader<RestClientBuilderResolver> sl = ServiceLoader.load(RestClientBuilderResolver.class, cl);
+        for (RestClientBuilderResolver spi : sl) {
+            if (instance != null) {
+                throw new IllegalStateException("Multiple RestClientBuilderResolver implementations found: "
+                                                + spi.getClass().getName() + " and "
+                                                + instance.getClass().getName());
             }
+            instance = spi;
         }
-        return resolver;
+
+        return instance;
     }
 
     /**

--- a/api/src/main/java/org/eclipse/microprofile/rest/client/spi/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/spi/package-info.java
@@ -23,5 +23,5 @@
  * provide additional functionality for MP Rest Clients.
  *
  */
-@org.osgi.annotation.versioning.Version("1.1")
+@org.osgi.annotation.versioning.Version("1.1.1")
 package org.eclipse.microprofile.rest.client.spi;

--- a/api/src/test/java/org/eclipse/microprofile/rest/client/ext/MockConfigProviderResolver.java
+++ b/api/src/test/java/org/eclipse/microprofile/rest/client/ext/MockConfigProviderResolver.java
@@ -32,6 +32,7 @@ public class MockConfigProviderResolver extends ConfigProviderResolver {
     public Config getConfig() {
         return new Config(){
             @Override
+            @SuppressWarnings("unchecked")
             public <T> T getValue(String propertyName, Class<T> propertyType) {
                 Map<String, String> props = getConfigSources().iterator().next().getProperties();
                 if (!props.containsKey(propertyName)) {

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>org.eclipse.microprofile.rest.client</groupId>
     <artifactId>microprofile-rest-client-parent</artifactId>
-    <version>1.3.5-SNAPSHOT</version>
+    <version>1.4-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>MicroProfile Rest Client</name>
     <description>Typesafe Rest Client APIs for MicroProfile</description>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -20,7 +20,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.rest.client</groupId>
         <artifactId>microprofile-rest-client-parent</artifactId>
-        <version>1.3.5-SNAPSHOT</version>
+        <version>1.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>microprofile-rest-client-spec</artifactId>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -21,7 +21,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.rest.client</groupId>
         <artifactId>microprofile-rest-client-parent</artifactId>
-        <version>1.3.5-SNAPSHOT</version>
+        <version>1.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>microprofile-rest-client-tck</artifactId>

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/AdditionalRegistrationTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/AdditionalRegistrationTest.java
@@ -77,7 +77,7 @@ public class AdditionalRegistrationTest extends Arquillian{
     @Test
     public void shouldRegisterAMultiTypedProviderInstance() {
         MultiTypedProvider provider = new MultiTypedProvider();
-        Class[] providerTypes = {ClientRequestFilter.class, ClientResponseFilter.class,
+        Class<?>[] providerTypes = {ClientRequestFilter.class, ClientResponseFilter.class,
             MessageBodyReader.class, MessageBodyWriter.class, ReaderInterceptor.class, WriterInterceptor.class,
             ResponseExceptionMapper.class, ParamConverterProvider.class};
         RestClientBuilder builder = RestClientBuilder.newBuilder().register(provider, providerTypes);
@@ -126,7 +126,7 @@ public class AdditionalRegistrationTest extends Arquillian{
 
     @Test
     public void shouldRegisterAMultiTypedProviderClass() {
-        Class[] providerTypes = {ClientRequestFilter.class, ClientResponseFilter.class,
+        Class<?>[] providerTypes = {ClientRequestFilter.class, ClientResponseFilter.class,
             MessageBodyReader.class, MessageBodyWriter.class, ReaderInterceptor.class, WriterInterceptor.class,
             ResponseExceptionMapper.class, ParamConverterProvider.class};
         RestClientBuilder builder = RestClientBuilder.newBuilder().register(MultiTypedProvider.class, providerTypes);

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/FeatureRegistrationTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/FeatureRegistrationTest.java
@@ -31,7 +31,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
 import javax.inject.Inject;
-import static org.eclipse.microprofile.rest.client.tck.WiremockArquillianTest.getStringURL;
 
 import static org.testng.Assert.assertTrue;
 

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/MultiTypedProvider.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/MultiTypedProvider.java
@@ -42,43 +42,44 @@ import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
-public class MultiTypedProvider implements ClientRequestFilter, ClientResponseFilter, MessageBodyReader, MessageBodyWriter,
-    ReaderInterceptor, WriterInterceptor, ResponseExceptionMapper, ParamConverterProvider{
+public class MultiTypedProvider implements ClientRequestFilter, ClientResponseFilter, MessageBodyReader<Object>,
+    MessageBodyWriter<Object>, ReaderInterceptor, WriterInterceptor, ResponseExceptionMapper<Throwable>,
+    ParamConverterProvider{
+
     @Override
     public void filter(ClientRequestContext requestContext) throws IOException {
-
     }
 
     @Override
     public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) throws IOException {
-
     }
 
     @Override
-    public boolean isReadable(Class type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+    public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
         return false;
     }
 
     @Override
-    public Object readFrom(Class type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap httpHeaders,
-                           InputStream entityStream) throws IOException, WebApplicationException {
+    public Object readFrom(Class<Object> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+        MultivaluedMap<String, String> httpHeaders, InputStream entityStream)
+        throws IOException, WebApplicationException {
         return null;
     }
 
     @Override
-    public boolean isWriteable(Class type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
         return false;
     }
 
     @Override
-    public long getSize(Object o, Class type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+    public long getSize(Object o, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
         return 0;
     }
 
     @Override
-    public void writeTo(Object o, Class type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap httpHeaders,
-                        OutputStream entityStream) throws IOException, WebApplicationException {
-
+    public void writeTo(Object t, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+            MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream)
+            throws IOException, WebApplicationException {
     }
 
     @Override
@@ -93,7 +94,6 @@ public class MultiTypedProvider implements ClientRequestFilter, ClientResponseFi
 
     @Override
     public void aroundWriteTo(WriterInterceptorContext context) throws IOException, WebApplicationException {
-
     }
 
     @Override

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TestParamConverterProvider.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TestParamConverterProvider.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Type;
 
 public class TestParamConverterProvider implements ParamConverterProvider {
     @Override
+    @SuppressWarnings("unchecked")
     public <T> ParamConverter<T> getConverter(Class<T> aClass, Type type, Annotation[] annotations) {
         if(String.class.isAssignableFrom(aClass)) {
             return (ParamConverter<T>) new TestParamConverter();


### PR DESCRIPTION
This pull request cherry-picks three commits from master branch (2.0 release):
- Removes compiler warnings
- Removes recursive classloader check in `loadSpi` method - #238 
- Adds `@Target` to the `@RestClient` annotation - #232 

A fourth commit updates the POMs to use "1.4-SNAPSHOT" (this is the only commit not already in master).