### PR TITLE
Update ParamConverterProvider test cases

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeWithBuiltProvidersTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeWithBuiltProvidersTest.java
@@ -28,6 +28,7 @@ import org.eclipse.microprofile.rest.client.tck.providers.TestMessageBodyWriter;
 import org.eclipse.microprofile.rest.client.tck.providers.TestParamConverterProvider;
 import org.eclipse.microprofile.rest.client.tck.providers.TestReaderInterceptor;
 import org.eclipse.microprofile.rest.client.tck.providers.TestWriterInterceptor;
+import org.eclipse.microprofile.rest.client.tck.providers.Widget;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -87,8 +88,8 @@ public class InvokeWithBuiltProvidersTest extends WiremockArquillianTest {
         String outputBody = "output body will be removed";
         String expectedReceivedBody = "this is the replaced writer "+inputBody;
         String expectedResponseBody = TestMessageBodyReader.REPLACED_BODY;
-        String id = "id";
-        String expectedId = "toStringid";
+        Widget id = new Widget("Battery", 3);
+        String expectedId = "Battery:3";
         stubFor(put(urlEqualTo("/"+expectedId))
             .willReturn(aResponse()
                 .withBody(outputBody)));

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeWithRegisteredProvidersTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/InvokeWithRegisteredProvidersTest.java
@@ -26,6 +26,7 @@ import org.eclipse.microprofile.rest.client.tck.providers.TestClientResponseFilt
 import org.eclipse.microprofile.rest.client.tck.providers.TestMessageBodyReader;
 import org.eclipse.microprofile.rest.client.tck.providers.TestReaderInterceptor;
 import org.eclipse.microprofile.rest.client.tck.providers.TestWriterInterceptor;
+import org.eclipse.microprofile.rest.client.tck.providers.Widget;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -88,8 +89,8 @@ public class InvokeWithRegisteredProvidersTest extends WiremockArquillianTest {
         String outputBody = "output body will be removed";
         String expectedReceivedBody = "this is the replaced writer "+inputBody;
         String expectedResponseBody = TestMessageBodyReader.REPLACED_BODY;
-        String id = "id";
-        String expectedId = "toStringid";
+        Widget id = new Widget("Keyboard", 123);
+        String expectedId = "Keyboard:123";
         stubFor(put(urlEqualTo("/"+expectedId))
             .willReturn(aResponse()
                 .withBody(outputBody)));

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/CDIInvokeWithRegisteredProvidersTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/CDIInvokeWithRegisteredProvidersTest.java
@@ -31,6 +31,7 @@ import org.eclipse.microprofile.rest.client.tck.providers.TestMessageBodyWriter;
 import org.eclipse.microprofile.rest.client.tck.providers.TestParamConverterProvider;
 import org.eclipse.microprofile.rest.client.tck.providers.TestReaderInterceptor;
 import org.eclipse.microprofile.rest.client.tck.providers.TestWriterInterceptor;
+import org.eclipse.microprofile.rest.client.tck.providers.Widget;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -167,8 +168,8 @@ public class CDIInvokeWithRegisteredProvidersTest extends WiremockArquillianTest
         String outputBody = "output body will be removed";
         String expectedReceivedBody = "this is the replaced writer "+inputBody;
         String expectedResponseBody = TestMessageBodyReader.REPLACED_BODY;
-        String id = "id";
-        String expectedId = "toStringid";
+        Widget id = new Widget("MyWidget", 7);
+        String expectedId = "MyWidget:7";
         stubFor(put(urlEqualTo("/"+expectedId))
             .willReturn(aResponse()
                 .withBody(outputBody)));

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/InterfaceBase.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/InterfaceBase.java
@@ -20,9 +20,11 @@ package org.eclipse.microprofile.rest.client.tck.interfaces;
 
 import javax.ws.rs.core.Response;
 
+import org.eclipse.microprofile.rest.client.tck.providers.Widget;
+
 public interface InterfaceBase {
 
     Response executePost(String body);
 
-    Response executePut(String id, String body);
+    Response executePut(Widget id, String body);
 }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/InterfaceWithProvidersDefined.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/InterfaceWithProvidersDefined.java
@@ -27,6 +27,7 @@ import org.eclipse.microprofile.rest.client.tck.providers.TestMessageBodyWriter;
 import org.eclipse.microprofile.rest.client.tck.providers.TestParamConverterProvider;
 import org.eclipse.microprofile.rest.client.tck.providers.TestReaderInterceptor;
 import org.eclipse.microprofile.rest.client.tck.providers.TestWriterInterceptor;
+import org.eclipse.microprofile.rest.client.tck.providers.Widget;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
@@ -56,5 +57,5 @@ public interface InterfaceWithProvidersDefined extends InterfaceBase {
     @PUT
     @Path("/{id}")
     @Override
-    Response executePut(@PathParam("id") String id, String body);
+    Response executePut(@PathParam("id") Widget id, String body);
 }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/InterfaceWithoutProvidersDefined.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/InterfaceWithoutProvidersDefined.java
@@ -28,6 +28,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.tck.providers.Widget;
 
 @Path("/")
 @Produces(MediaType.TEXT_PLAIN)
@@ -42,5 +43,5 @@ public interface InterfaceWithoutProvidersDefined extends InterfaceBase {
     @PUT
     @Path("/{id}")
     @Override
-    Response executePut(@PathParam("id") String id, String body);
+    Response executePut(@PathParam("id") Widget id, String body);
 }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/InterfaceWithoutProvidersDefinedWithConfigKey.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/InterfaceWithoutProvidersDefinedWithConfigKey.java
@@ -28,6 +28,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.tck.providers.Widget;
 
 @Path("/")
 @Produces(MediaType.TEXT_PLAIN)
@@ -42,5 +43,5 @@ public interface InterfaceWithoutProvidersDefinedWithConfigKey extends Interface
     @PUT
     @Path("/{id}")
     @Override
-    Response executePut(@PathParam("id") String id, String body);
+    Response executePut(@PathParam("id") Widget id, String body);
 }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TestParamConverter.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/TestParamConverter.java
@@ -20,14 +20,14 @@ package org.eclipse.microprofile.rest.client.tck.providers;
 
 import javax.ws.rs.ext.ParamConverter;
 
-public class TestParamConverter implements ParamConverter<String>{
+public class TestParamConverter implements ParamConverter<Widget>{
     @Override
-    public String fromString(String s) {
-        return "fromString"+s;
+    public Widget fromString(String s) {
+        return s == null ? null : Widget.fromString(s);
     }
 
     @Override
-    public String toString(String s) {
-        return "toString"+s;
+    public String toString(Widget w) {
+        return w == null ? null : w.toString();
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/Widget.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/Widget.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.providers;
+
+
+
+public class Widget {
+
+    private String name;
+    private int length;
+    
+    public static Widget fromString(String s) {
+        String[] split = s.split(":");
+        return new Widget(split[0], Integer.parseInt(split[1]));
+    }
+
+    public Widget(String name, int length) {
+        this.name = name;
+        this.length = length;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getLength() {
+        return length;
+    }
+
+    public void setLength(int length) {
+        this.length = length;
+    }
+
+    @Override
+    public String toString() {
+        return name + ":" + length;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return (o instanceof Widget) && o != null && ((Widget)o).name.equals(name) && ((Widget)o).length == length;
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
+}


### PR DESCRIPTION
This change converts between Widget and String rather than String and String.  Functionally, everything is the same as before, but now it is more clear what is being tested.

Resolves issue #74. 