### PR TITLE
[#249] Make `@Context` injection optional

### DIFF
--- a/spec/src/main/asciidoc/integration.asciidoc
+++ b/spec/src/main/asciidoc/integration.asciidoc
@@ -56,9 +56,11 @@ comma-separated list of headers in the following MicroProfile Config property:
 
 `org.eclipse.microprofile.rest.client.propagateHeaders`.
 
-If the client interface is used within a JAX-RS context, then the implementation must support injection of `@Context` 
+If the client interface is used within a JAX-RS context, then the implementation may support injection of `@Context` 
 fields and methods into custom `ClientHeadersFactory` instances. The injected objects are related to the JAX-RS context
 (i.e. an injected `UriInfo` will be specific to the JAX-RS resource's URI, not the URI of the MP Rest Client interface).
+This injection is optional for the implementation, so the only portable injection mechanism of `ClientHeadersFactory`
+instances is `@Inject` when the client is managed by CDI.
 
 === Other MicroProfile Technologies
 

--- a/spec/src/main/asciidoc/release_notes.asciidoc
+++ b/spec/src/main/asciidoc/release_notes.asciidoc
@@ -23,7 +23,7 @@
 
 Changes since 1.3:
 
-- Ensure CDI and JAX-RS injection into `ClientHeadersFactory`.
+- Ensure CDI and optionally JAX-RS injection into `ClientHeadersFactory`.
 - Specified `@Target` to `@RestClient` annotation.
 - Removed recursive classloader check when resolving service loader for Rest Client SPI.
 - Updated ParamConverter TCK test case to be more realistic (converting String-to-Widget rather than String-to-String).


### PR DESCRIPTION
Per conversation in gitter, we decided that `@Context` injection of JAX-RS components should be optional for this release (we can make it required in 2.0 if we choose).  This resolves issue #249.

@ronsigal - I can't add you as a reviewer, but please take a look at the changes and approve (or add comments) as applicable.  Thanks!