### PR TITLE
Remove obsolete constructor target for RestClient annotation

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/rest/client/inject/RestClient.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/inject/RestClient.java
@@ -36,7 +36,7 @@ import java.lang.annotation.Target;
  *
  * This will cause the injection point to be satisfied by the MicroProfile Rest Client runtime.
  */
-@Target({ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE})
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE})
 @Qualifier
 @Documented
 @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
Since, the `@RestClient` annotation makes no sense to be used on a constructor (meaning to directly annotate the constructor), I removed the `ElementType.CONSTRUCTOR`.

Fixes #257, follow up for #259.