### PR TITLE
Allow configuring timeout test

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/timeout/TimeoutBuilderIndependentOfMPConfigTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/timeout/TimeoutBuilderIndependentOfMPConfigTest.java
@@ -67,7 +67,8 @@ public class TimeoutBuilderIndependentOfMPConfigTest extends TimeoutTestBase {
     @Override
     protected void checkTimeElapsed(long elapsed) {
         assertTrue(elapsed >= 5);
-        // allow an extra 10 seconds cushion for slower test machines
-        assertTrue(elapsed < 15);
+        // allow extra seconds cushion for slower test machines
+        final long elapsedLimit = 5 + TIMEOUT_CUSHION;
+        assertTrue(elapsed < elapsedLimit, "Elapsed time expected under " + elapsedLimit + " secs, but was " + elapsed + " secs.");
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/timeout/TimeoutTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/timeout/TimeoutTest.java
@@ -61,7 +61,8 @@ public class TimeoutTest extends TimeoutTestBase {
     @Override
     protected void checkTimeElapsed(long elapsed) {
         assertTrue(elapsed >= 5);
-        // allow an extra 10 seconds cushion for slower test machines
-        assertTrue(elapsed < 15);
+        // allow extra seconds cushion for slower test machines
+        final long elapsedLimit = 5 + TIMEOUT_CUSHION;
+        assertTrue(elapsed < elapsedLimit, "Elapsed time expected under " + elapsedLimit + " secs, but was " + elapsed + " secs.");
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/timeout/TimeoutTestBase.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/timeout/TimeoutTestBase.java
@@ -47,6 +47,13 @@ public abstract class TimeoutTestBase extends WiremockArquillianTest {
                 "http://microprofile.io:1234/null")
         );
 
+    protected static final int TIMEOUT_CUSHION =
+        AccessController.doPrivileged((PrivilegedAction<Integer>) () ->
+            Integer.getInteger(
+                "org.eclipse.microprofile.rest.client.tck.timeoutCushion",
+                10)
+        );
+
     @Test(expectedExceptions={ProcessingException.class})
     public void testConnectTimeout() throws Exception {
 

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/timeout/TimeoutViaMPConfigTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/timeout/TimeoutViaMPConfigTest.java
@@ -67,7 +67,8 @@ public class TimeoutViaMPConfigTest extends TimeoutTestBase {
     @Override
     protected void checkTimeElapsed(long elapsed) {
         assertTrue(elapsed >= 7);
-        // allow an extra 10 seconds cushion for slower test machines
-        assertTrue(elapsed < 17);
+        // allow extra seconds cushion for slower test machines
+        final long elapsedLimit = 7 + TIMEOUT_CUSHION;
+        assertTrue(elapsed < elapsedLimit, "Elapsed time expected under " + elapsedLimit + " secs, but was " + elapsed + " secs.");
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/timeout/TimeoutViaMPConfigWithConfigKeyTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/timeout/TimeoutViaMPConfigWithConfigKeyTest.java
@@ -68,7 +68,8 @@ public class TimeoutViaMPConfigWithConfigKeyTest extends TimeoutTestBase {
     @Override
     protected void checkTimeElapsed(long elapsed) {
         assertTrue(elapsed >= 7);
-        // allow an extra 10 seconds cushion for slower test machines
-        assertTrue(elapsed < 17);
+        // allow extra seconds cushion for slower test machines
+        final long elapsedLimit = 7 + TIMEOUT_CUSHION;
+        assertTrue(elapsed < elapsedLimit, "Elapsed time expected under " + elapsedLimit + " secs, but was " + elapsed + " secs.");
     }
 }


### PR DESCRIPTION
We have failures from time to time when running the TCK in CI environment with limited resources.
So I'd like to make the timeout tests configurable.