### PR TITLE
[#268] Support automatically following redirects

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2020 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -215,7 +215,15 @@ public interface RestClientBuilder extends Configurable<RestClientBuilder> {
      */
     RestClientBuilder hostnameVerifier(HostnameVerifier hostnameVerifier);
 
-
+    /**
+     * Specifies whether client built by this builder should follow HTTP
+     * redirect responses (30x) or not.
+     * 
+     * @param follow - true if the client should follow HTTP redirects, false if not.
+     * @return the current builder with the followRedirect property set.
+     * @since 2.0
+     */
+    RestClientBuilder followRedirects(boolean follow);
 
     /**
      * Based on the configured RestClientBuilder, creates a new instance of the

--- a/api/src/test/java/org/eclipse/microprofile/rest/client/BuilderImpl1.java
+++ b/api/src/test/java/org/eclipse/microprofile/rest/client/BuilderImpl1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2020 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,6 +68,11 @@ public class BuilderImpl1 extends AbstractBuilder {
 
     @Override
     public RestClientBuilder readTimeout(long timeout, TimeUnit unit) {
+        throw new IllegalStateException("not implemented");
+    }
+
+    @Override
+    public RestClientBuilder followRedirects(boolean follow) {
         throw new IllegalStateException("not implemented");
     }
 

--- a/api/src/test/java/org/eclipse/microprofile/rest/client/BuilderImpl2.java
+++ b/api/src/test/java/org/eclipse/microprofile/rest/client/BuilderImpl2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2020 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,6 +69,11 @@ public class BuilderImpl2 extends AbstractBuilder {
 
     @Override
     public RestClientBuilder readTimeout(long timeout, TimeUnit unit) {
+        throw new IllegalStateException("not implemented");
+    }
+
+    @Override
+    public RestClientBuilder followRedirects(boolean follow) {
         throw new IllegalStateException("not implemented");
     }
 

--- a/spec/src/main/asciidoc/cdi.asciidoc
+++ b/spec/src/main/asciidoc/cdi.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017-2019 Contributors to the Eclipse Foundation
+// Copyright (c) 2017-2020 Contributors to the Eclipse Foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -84,6 +84,7 @@ The values of the following properties will be provided via MicroProfile Config:
 - `com.mycompany.remoteServices.MyServiceClient/mp-rest/providers/com.mycompany.MyProvider/priority` will override the priority of the provider for this interface.
 - `com.mycompany.remoteServices.MyServiceClient/mp-rest/connectTimeout`: Timeout specified in milliseconds to wait to connect to the remote endpoint.
 - `com.mycompany.remoteServices.MyServiceClient/mp-rest/readTimeout`: Timeout specified in milliseconds to wait for a response from the remote endpoint.
+- `com.mycompany.remoteServices.MyServiceClient/mp-rest/followRedirects`: A boolean value (Any value other than "true" will be interpreted as "false") used to determine whether the client should follow HTTP redirect responses.
 
 Implementations may support other custom properties registered in similar fashions or other ways.
 
@@ -116,6 +117,7 @@ Then config properties can be specified like:
 - `myClient/mp-rest/providers/com.mycompany.MyProvider/priority`
 - `myClient/mp-rest/connectTimeout`
 - `myClient/mp-rest/readTimeout`
+- `myClient/mp-rest/followRedirects`
 
 Multiple client interfaces may have the same configKey value, which would allow many interfaces to be configured with a single MP Config property.
 

--- a/spec/src/main/asciidoc/clientexamples.asciidoc
+++ b/spec/src/main/asciidoc/clientexamples.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017-2019 Contributors to the Eclipse Foundation
+// Copyright (c) 2017-2020 Contributors to the Eclipse Foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -148,6 +148,22 @@ By default, no `ClientHeadersFactory` implementation is used. To enable a `Clien
 implementation must invoke the `DefaultClientHeadersFactoryImpl`. This default factory will propagate specified headers from the inbound JAX-RS request to the outbound request - these headers are specified with a comma-separated list using the following MicroProfile Config property:
 
 `org.eclipse.microprofile.rest.client.propagateHeaders`
+
+=== Following Redirect Responses
+
+By default, a Rest Client instance will not automatically follow redirect responses. Redirect responses are typically responses with status codes in the 300 range and include `Location` header that indicates the URL of the redirected resource.
+
+To enable a client instance to automatically follow redirect responses, the builder must be configured using the `followRedirects(true)` method. For example:
+
+[source, java]
+----
+RedirectClient client = RestClientBuilder.newBuilder()
+                                         .baseUri(someUri)
+                                         .followRedirects(true)
+                                         .build(RedirectClient.class);
+----
+
+Alternatively, if the client is instantiated and injected using CDI, then it can be configured to follow redirect responses using the `<client_interface_name>/mp-rest/followRedirects` MP Config property. See <<cdi.asciidoc#mpconfig>> for more details.
 
 === Invalid Client Interface Examples
 

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/FollowRedirectsTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/FollowRedirectsTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
+import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApiWithConfigKey;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.core.Response;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class FollowRedirectsTest extends WiremockArquillianTest{
+    private static final String FOLLOWED_REDIRECT = "followed redirect";
+    private static final String DID_NOT_FOLLOW_REDIRECT = "did not follow redirect";
+    private static final String LOCATION = "Location";
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, 
+                FollowRedirectsTest.class.getSimpleName()+".war")
+            .addClasses(SimpleGetApi.class, SimpleGetApiWithConfigKey.class, WiremockArquillianTest.class);
+    }
+
+    @BeforeMethod
+    public void reset() {
+        WireMock.reset();
+    }
+
+    @Test
+    public void test301Default() throws Exception {
+        testDefault(301, getDefaultClientInstance());
+    }
+
+    @Test
+    public void test301Follows() throws Exception {
+        testFollows(301, getConfiguredClientInstance());
+    }
+
+    @Test
+    public void test302Default() throws Exception {
+        testDefault(302, getDefaultClientInstance());
+    }
+
+    @Test
+    public void test302Follows() throws Exception {
+        testFollows(302, getConfiguredClientInstance());
+    }
+
+    @Test
+    public void test303Default() throws Exception {
+        testDefault(303, getDefaultClientInstance());
+    }
+
+    @Test
+    public void test303Follows() throws Exception {
+        testFollows(303, getConfiguredClientInstance());
+    }
+
+    @Test
+    public void test307Default() throws Exception {
+        testDefault(307, getDefaultClientInstance());
+    }
+
+    @Test
+    public void test307Follows() throws Exception {
+        testFollows(307, getConfiguredClientInstance());
+    }
+
+    protected SimpleGetApi getDefaultClientInstance() {
+        return RestClientBuilder.newBuilder().baseUri(getServerURI()).build(SimpleGetApi.class);
+    }
+
+    protected SimpleGetApiWithConfigKey getConfiguredClientInstance() {
+        return RestClientBuilder.newBuilder().baseUri(getServerURI()).followRedirects(true)
+                .build(SimpleGetApiWithConfigKey.class);
+    }
+
+    public static void testDefault(int redirectCode, SimpleGetApi defaultClient) throws Exception {
+        try (Response response = execute(defaultClient, redirectCode)) {
+            assertEquals(response.getStatus(), redirectCode);
+            assertEquals(response.getHeaderString(LOCATION), getStringURL() + "redirected");
+            assertEquals(response.readEntity(String.class), DID_NOT_FOLLOW_REDIRECT);
+
+            verify(1, getRequestedFor(urlEqualTo("/")));
+            verify(0, getRequestedFor(urlEqualTo("/redirected")));
+        }
+    }
+
+    public static void testFollows(int redirectCode, SimpleGetApi followingClient) throws Exception {
+        try (Response response = execute(followingClient, redirectCode)) {
+            assertEquals(response.getStatus(), 200);
+            assertNull(response.getHeaderString(LOCATION));
+            assertEquals(response.readEntity(String.class), FOLLOWED_REDIRECT);
+
+            verify(1, getRequestedFor(urlEqualTo("/")));
+            verify(1, getRequestedFor(urlEqualTo("/redirected")));
+        }
+    }
+
+    private static Response execute(SimpleGetApi simpleGetApi, int redirectCode) throws Exception {
+        stubFor(get(urlEqualTo("/"))
+            .willReturn(aResponse()
+                .withStatus(redirectCode)
+                .withBody(DID_NOT_FOLLOW_REDIRECT)
+                .withHeader(LOCATION, getStringURL() + "redirected")));
+        stubFor(get(urlEqualTo("/redirected"))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withBody(FOLLOWED_REDIRECT)));
+
+        return simpleGetApi.executeGet();
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/CDIFollowRedirectsTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/CDIFollowRedirectsTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2020 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.cditests;
+
+import static org.eclipse.microprofile.rest.client.tck.FollowRedirectsTest.testDefault;
+import static org.eclipse.microprofile.rest.client.tck.FollowRedirectsTest.testFollows;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.eclipse.microprofile.rest.client.tck.FollowRedirectsTest;
+import org.eclipse.microprofile.rest.client.tck.WiremockArquillianTest;
+import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
+import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApiWithConfigKey;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import javax.inject.Inject;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+
+
+/**
+ * Verifies auto following redirects is performed when configured via MP Confg and CDI.
+ */
+public class CDIFollowRedirectsTest extends WiremockArquillianTest {
+    @Inject
+    @RestClient
+    private SimpleGetApi defaultClient;
+
+    @Inject
+    @RestClient
+    private SimpleGetApiWithConfigKey redirectingClient;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        String urlProperty1 = SimpleGetApi.class.getName() + "/mp-rest/uri=" + getStringURL();
+        String urlProperty2 = "myConfigKey/mp-rest/uri=" + getStringURL();
+        String redirectProperty = "myConfigKey/mp-rest/followRedirects=true";
+        String simpleName = CDIFollowRedirectsTest.class.getSimpleName();
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, simpleName + ".jar")
+            .addClasses(SimpleGetApi.class, SimpleGetApiWithConfigKey.class, 
+                        FollowRedirectsTest.class, WiremockArquillianTest.class)
+            .addAsManifestResource(new StringAsset(String.format(redirectProperty + "%n" + urlProperty1 + "%n" + urlProperty2)),
+                                                   "microprofile-config.properties")
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        return ShrinkWrap.create(WebArchive.class, simpleName + ".war")
+            .addAsLibrary(jar)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @BeforeMethod
+    public void reset() {
+        WireMock.reset();
+    }
+
+    @Test
+    public void test301Default() throws Exception {
+        testDefault(301, defaultClient);
+    }
+
+    @Test
+    public void test301Follows() throws Exception {
+        testFollows(301, redirectingClient);
+    }
+
+    @Test
+    public void test302Default() throws Exception {
+        testDefault(302, defaultClient);
+    }
+
+    @Test
+    public void test302Follows() throws Exception {
+        testFollows(302, redirectingClient);
+    }
+
+    @Test
+    public void test303Default() throws Exception {
+        testDefault(303, defaultClient);
+    }
+
+    @Test
+    public void test303Follows() throws Exception {
+        testFollows(303, redirectingClient);
+    }
+
+    @Test
+    public void test307Default() throws Exception {
+        testDefault(307, defaultClient);
+    }
+
+    @Test
+    public void test307Follows() throws Exception {
+        testFollows(307, redirectingClient);
+    }
+}


### PR DESCRIPTION
Fixes #268 - allows users to configure whether the MP Rest Client instances should automatically follow redirect responses (301, 302, 303, 307 - w/ `Location` header) or not.  Default is to not automatically follow.