### PR TITLE
[#55] Proxy server support

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
@@ -226,6 +226,17 @@ public interface RestClientBuilder extends Configurable<RestClientBuilder> {
     RestClientBuilder followRedirects(boolean follow);
 
     /**
+     * Specifies the HTTP proxy hostname/IP address and port to use for requests from client instances.
+     * 
+     * @param proxyHost - hostname or IP address of proxy server - must be non-null
+     * @param proxyPort - port of proxy server
+     * @throws IllegalArgumentException if the <code>proxyHost</code> is null or the <code>proxyPort</code> is invalid
+     * @return the current builder with the proxy host set
+     * @since 2.0
+     */
+    RestClientBuilder proxyAddress(String proxyHost, int proxyPort);
+
+    /**
      * Based on the configured RestClientBuilder, creates a new instance of the
      * given REST interface to invoke API calls against.
      *

--- a/api/src/test/java/org/eclipse/microprofile/rest/client/BuilderImpl1.java
+++ b/api/src/test/java/org/eclipse/microprofile/rest/client/BuilderImpl1.java
@@ -76,6 +76,10 @@ public class BuilderImpl1 extends AbstractBuilder {
         throw new IllegalStateException("not implemented");
     }
 
+    public RestClientBuilder proxyAddress(String proxyHost, int proxyPort) {
+        throw new IllegalStateException("not implemented");
+    }
+
     @Override
     public <T> T build(Class<T> clazz) {
         throw new IllegalStateException("not implemented");

--- a/api/src/test/java/org/eclipse/microprofile/rest/client/BuilderImpl2.java
+++ b/api/src/test/java/org/eclipse/microprofile/rest/client/BuilderImpl2.java
@@ -77,6 +77,10 @@ public class BuilderImpl2 extends AbstractBuilder {
         throw new IllegalStateException("not implemented");
     }
 
+    public RestClientBuilder proxyAddress(String proxyHost, int proxyPort) {
+        throw new IllegalStateException("not implemented");
+    }
+
     @Override
     public <T> T build(Class<T> clazz) {
         throw new IllegalStateException("not implemented");

--- a/spec/src/main/asciidoc/cdi.asciidoc
+++ b/spec/src/main/asciidoc/cdi.asciidoc
@@ -85,6 +85,7 @@ The values of the following properties will be provided via MicroProfile Config:
 - `com.mycompany.remoteServices.MyServiceClient/mp-rest/connectTimeout`: Timeout specified in milliseconds to wait to connect to the remote endpoint.
 - `com.mycompany.remoteServices.MyServiceClient/mp-rest/readTimeout`: Timeout specified in milliseconds to wait for a response from the remote endpoint.
 - `com.mycompany.remoteServices.MyServiceClient/mp-rest/followRedirects`: A boolean value (Any value other than "true" will be interpreted as "false") used to determine whether the client should follow HTTP redirect responses.
+- `com.mycompany.remoteServices.MyServiceClient/mp-rest/proxyAddress`: A string value in the form of `<proxyHost>:<proxyPort>` that specifies the HTTP proxy server hostname (or IP address) and port for requests of this client to use.
 
 Implementations may support other custom properties registered in similar fashions or other ways.
 
@@ -118,6 +119,7 @@ Then config properties can be specified like:
 - `myClient/mp-rest/connectTimeout`
 - `myClient/mp-rest/readTimeout`
 - `myClient/mp-rest/followRedirects`
+- `myClient/mp-rest/proxyAddresses`
 
 Multiple client interfaces may have the same configKey value, which would allow many interfaces to be configured with a single MP Config property.
 

--- a/spec/src/main/asciidoc/clientexamples.asciidoc
+++ b/spec/src/main/asciidoc/clientexamples.asciidoc
@@ -165,6 +165,20 @@ RedirectClient client = RestClientBuilder.newBuilder()
 
 Alternatively, if the client is instantiated and injected using CDI, then it can be configured to follow redirect responses using the `<client_interface_name>/mp-rest/followRedirects` MP Config property. See <<cdi.asciidoc#mpconfig>> for more details.
 
+=== Using HTTP Proxy Servers
+
+In some environments it may be necessary to route requests through a HTTP proxy server to reach the REST endpoint. Users may configure the proxy server's address (hostname and port) using the `proxyAddress` method on `RestClientBuilder`. For example:
+
+[source, java]
+----
+ProxiedClient client = RestClientBuilder.newBuilder()
+                                        .baseUri(someUri)
+                                        .proxyAddress("myproxy.mycompany.com", 8080)
+                                        .build(ProxiedClient.class);
+----
+
+Alternatively, if the client is instantiated and injected using CDI, then the proxy address can be configured using the `<client_interface_name>/mp-rest/proxyAddress` MP Config property. See <<cdi.asciidoc#mpconfig>> for more details.
+
 === Invalid Client Interface Examples
 
 Invalid client interfaces will result in a RestClientDefinitionException (which may be wrapped in a `DefinitionException` if using CDI).  Invalid interfaces can include:

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ProxyServerTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ProxyServerTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck;
+
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.Response;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static org.testng.Assert.assertEquals;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.URI;
+
+public class ProxyServerTest extends WiremockArquillianTest {
+    public static final int DESTINATION_SERVER_PORT = Integer.getInteger("org.eclipse.microprofile.rest.client.ssl.port", 8948);
+    private static final Server DESTINATION_SERVER = new Server(DESTINATION_SERVER_PORT);
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, ProxyServerTest.class.getSimpleName() + ".war")
+                .addClasses(SimpleGetApi.class, WiremockArquillianTest.class);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testNullHostName() throws Exception {
+        RestClientBuilder.newBuilder().proxyAddress(null, 1234);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testInvalidPortNumber() throws Exception {
+        RestClientBuilder.newBuilder().proxyAddress("microprofile.io", 0);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testInvalidPortNumber1() throws Exception {
+        RestClientBuilder.newBuilder().proxyAddress("microprofile.io", -1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testInvalidPortNumber2() throws Exception {
+        RestClientBuilder.newBuilder().proxyAddress("microprofile.io", 65536);
+    }
+
+    @Test
+    public void testProxy() throws Exception {
+        stubFor(get(urlMatching("/.*")).willReturn(
+            aResponse().proxiedFrom("http://localhost:" + DESTINATION_SERVER_PORT)
+                       .withAdditionalRequestHeader("X-Via", "WireMockProxy")));
+        try {
+            startDestinationServer("foo");
+            SimpleGetApi client = RestClientBuilder.newBuilder()
+                                                   .proxyAddress("localhost", getPort())
+                                                   .baseUri(URI.create("http://localhost:" + DESTINATION_SERVER_PORT + "/testProxy"))
+                                                   .build(SimpleGetApi.class);
+            Response response = client.executeGet();
+            assertEquals(response.getStatus(), 200);
+            assertEquals(response.readEntity(String.class).trim(), "foo");
+            assertEquals(response.getHeaderString("X-Via"), "WireMockProxy");
+        }
+        finally {
+            stopDestinationServer();
+        }
+    }
+
+    public static void startDestinationServer(String responseContent) {
+        DESTINATION_SERVER.setHandler(
+            new AbstractHandler() {
+                @Override
+                public void handle(String path,
+                                   Request request,
+                                   HttpServletRequest httpRequest,
+                                   HttpServletResponse response) throws IOException {
+                    response.setHeader("Content-Type", "text/plain");
+                    response.setHeader("X-Via", request.getHeader("X-Via"));
+                    try (PrintWriter writer = response.getWriter()) {
+                        writer.println(responseContent);
+                    }
+                }
+            });
+        try {
+            DESTINATION_SERVER.start();
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Failed to start destination server", e);
+        }
+    }
+
+    public static void stopDestinationServer() {
+        try {
+            DESTINATION_SERVER.stop();
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Failed to stop destination server", e);
+        }
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/WiremockArquillianTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/WiremockArquillianTest.java
@@ -33,7 +33,7 @@ public abstract class WiremockArquillianTest extends Arquillian {
     private static String scheme;
     private static String context;
 
-    private static Integer getPort() {
+    public static Integer getPort() {
         if(port == null) {
             setupWireMockConnection();
         }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/CDIProxyServerTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/CDIProxyServerTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.cditests;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.eclipse.microprofile.rest.client.tck.ProxyServerTest;
+import org.eclipse.microprofile.rest.client.tck.WiremockArquillianTest;
+import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static org.eclipse.microprofile.rest.client.tck.ProxyServerTest.DESTINATION_SERVER_PORT;
+import static org.eclipse.microprofile.rest.client.tck.ProxyServerTest.startDestinationServer;
+import static org.eclipse.microprofile.rest.client.tck.ProxyServerTest.stopDestinationServer;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Verifies via CDI injection that you can use a programmatic interface.  verifies that the interface has Dependent scope.
+ */
+public class CDIProxyServerTest extends WiremockArquillianTest{
+    @Inject
+    @RestClient
+    private SimpleGetApi client;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        String uriProperty = SimpleGetApi.class.getName()+"/mp-rest/uri=" + getStringURL() + "testProxyCDI";
+        String proxyProperty = SimpleGetApi.class.getName()+"/mp-rest/proxyAddress=localhost:" + getPort();
+        String simpleName = CDIProxyServerTest.class.getSimpleName();
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, simpleName + ".jar")
+            .addClasses(SimpleGetApi.class, WiremockArquillianTest.class, ProxyServerTest.class)
+            .addAsManifestResource(new StringAsset(String.format(uriProperty+"%n"+proxyProperty)),
+                                                                 "microprofile-config.properties")
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        return ShrinkWrap.create(WebArchive.class, simpleName + ".war")
+            .addAsLibrary(jar)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    public void testProxy() throws Exception {
+        stubFor(get(urlMatching("/.*")).willReturn(
+            aResponse().proxiedFrom("http://localhost:" + DESTINATION_SERVER_PORT)
+                       .withAdditionalRequestHeader("X-Via", "CDIWireMockProxy")));
+        try {
+            startDestinationServer("bar");
+            Response response = client.executeGet();
+            assertEquals(response.getStatus(), 200);
+            assertEquals(response.readEntity(String.class).trim(), "bar");
+            assertEquals(response.getHeaderString("X-Via"), "CDIWireMockProxy");
+        }
+        finally {
+            stopDestinationServer();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #55 - adds new `RestClientBuilder` method `proxyAddress(String proxyHost, int proxyPort)` and the MP Config equivalent (`<interfeaceName>/mp-rest/proxyAddress=someHost:8080`).  Includes API changes, spec text and TCK tests (for both programatic and CDI builders).