### PR TITLE
[#217] Handling different QueryParam styles

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
@@ -29,6 +29,7 @@ import javax.net.ssl.SSLContext;
 import javax.ws.rs.core.Configurable;
 import java.util.concurrent.ExecutorService;
 
+import org.eclipse.microprofile.rest.client.ext.QueryParamStyle;
 import org.eclipse.microprofile.rest.client.spi.RestClientBuilderListener;
 import org.eclipse.microprofile.rest.client.spi.RestClientBuilderResolver;
 
@@ -235,6 +236,15 @@ public interface RestClientBuilder extends Configurable<RestClientBuilder> {
      * @since 2.0
      */
     RestClientBuilder proxyAddress(String proxyHost, int proxyPort);
+
+    /**
+     * Specifies the URI formatting style to use when multiple query parameter values are passed to the client.
+     * 
+     * @param style - the URI formatting style to use for multiple query parameter values
+     * @return the current builder with the style of query params set
+     * @since 2.0
+     */
+    RestClientBuilder queryParamStyle(QueryParamStyle style);
 
     /**
      * Based on the configured RestClientBuilder, creates a new instance of the

--- a/api/src/main/java/org/eclipse/microprofile/rest/client/ext/QueryParamStyle.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/ext/QueryParamStyle.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.ext;
+
+/**
+ * A QueryParamStyle enum is used to specify how multiple values are handled
+ * when constructing the query portion of the URI. For example, a client
+ * interface may take a collection of strings as it's query parameter. This enum
+ * determines the style:
+ * 
+ * <pre>
+ * public interface MultiParamClient {
+ *     void sendMultipleQueryParams(&#064;QueryParam("foo") List&lt;String&gt; strings);
+ * }
+ * </pre>
+ * 
+ * The style selected when building this client instance will determine the format
+ * of the query portion of the URI.
+ *
+ * @since 2.0
+ */
+public enum QueryParamStyle {
+
+    /**
+     * Multiple parameter instances, e.g.:
+     * <code>foo=v1&amp;foot=v2&amp;foo=v3</code>
+     * 
+     * This is the default if no style is configured.
+     */
+    MULTI_PAIRS,
+
+    /** A single parameter instance with multiple, comma-separated values, e.g.:
+     * <code>foo=v1,v2,v3</code>
+     */
+    COMMA_SEPARATED,
+
+    /**
+     * Multiple parameter instances with square brackets for each parameter, e.g.:
+     * <code>foo[]=v1&amp;foo[]=v2&amp;foo[]=v3</code>
+     */
+    ARRAY_PAIRS
+}

--- a/api/src/test/java/org/eclipse/microprofile/rest/client/BuilderImpl1.java
+++ b/api/src/test/java/org/eclipse/microprofile/rest/client/BuilderImpl1.java
@@ -19,6 +19,9 @@ package org.eclipse.microprofile.rest.client;
 import javax.annotation.Priority;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
+
+import org.eclipse.microprofile.rest.client.ext.QueryParamStyle;
+
 import java.net.URI;
 import java.net.URL;
 import java.security.KeyStore;
@@ -76,7 +79,13 @@ public class BuilderImpl1 extends AbstractBuilder {
         throw new IllegalStateException("not implemented");
     }
 
+    @Override
     public RestClientBuilder proxyAddress(String proxyHost, int proxyPort) {
+        throw new IllegalStateException("not implemented");
+    }
+
+    @Override
+    public RestClientBuilder queryParamStyle(QueryParamStyle style) {
         throw new IllegalStateException("not implemented");
     }
 

--- a/api/src/test/java/org/eclipse/microprofile/rest/client/BuilderImpl2.java
+++ b/api/src/test/java/org/eclipse/microprofile/rest/client/BuilderImpl2.java
@@ -19,6 +19,9 @@ package org.eclipse.microprofile.rest.client;
 import javax.annotation.Priority;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
+
+import org.eclipse.microprofile.rest.client.ext.QueryParamStyle;
+
 import java.net.URI;
 import java.net.URL;
 import java.security.KeyStore;
@@ -78,6 +81,11 @@ public class BuilderImpl2 extends AbstractBuilder {
     }
 
     public RestClientBuilder proxyAddress(String proxyHost, int proxyPort) {
+        throw new IllegalStateException("not implemented");
+    }
+
+    @Override
+    public RestClientBuilder queryParamStyle(QueryParamStyle style) {
         throw new IllegalStateException("not implemented");
     }
 

--- a/spec/src/main/asciidoc/cdi.asciidoc
+++ b/spec/src/main/asciidoc/cdi.asciidoc
@@ -86,6 +86,7 @@ The values of the following properties will be provided via MicroProfile Config:
 - `com.mycompany.remoteServices.MyServiceClient/mp-rest/readTimeout`: Timeout specified in milliseconds to wait for a response from the remote endpoint.
 - `com.mycompany.remoteServices.MyServiceClient/mp-rest/followRedirects`: A boolean value (Any value other than "true" will be interpreted as "false") used to determine whether the client should follow HTTP redirect responses.
 - `com.mycompany.remoteServices.MyServiceClient/mp-rest/proxyAddress`: A string value in the form of `<proxyHost>:<proxyPort>` that specifies the HTTP proxy server hostname (or IP address) and port for requests of this client to use.
+- `com.mycompany.remoteServices.MyServiceClient/mp-rest/queryParamStyle`: An enumerated type string value with possible values of "MULTI_PAIRS" (default), "COMMA_SEPARATED", or "ARRAY_PAIRS" that specifies the format in which multiple values for the same query parameter is used.
 
 Implementations may support other custom properties registered in similar fashions or other ways.
 
@@ -120,6 +121,7 @@ Then config properties can be specified like:
 - `myClient/mp-rest/readTimeout`
 - `myClient/mp-rest/followRedirects`
 - `myClient/mp-rest/proxyAddresses`
+- `myClient/mp-rest/queryParamStyle`
 
 Multiple client interfaces may have the same configKey value, which would allow many interfaces to be configured with a single MP Config property.
 

--- a/spec/src/main/asciidoc/clientexamples.asciidoc
+++ b/spec/src/main/asciidoc/clientexamples.asciidoc
@@ -179,6 +179,39 @@ ProxiedClient client = RestClientBuilder.newBuilder()
 
 Alternatively, if the client is instantiated and injected using CDI, then the proxy address can be configured using the `<client_interface_name>/mp-rest/proxyAddress` MP Config property. See <<cdi.asciidoc#mpconfig>> for more details.
 
+=== Specifying Query Parameter Style for multi-valued parameters
+
+Different RESTful services may require different styles of query parameters when handling multiple values for the same
+query parameter. For example, some servers will require query parameters to be expanded into multiple key/value pairs 
+such as `key=value1&key=value2&key=value3`. Others will require parameters to be separated by comma with a single
+key/value pair such as `key=value1,value2,value3`. Still others will require an array-like syntax using multiple
+key/value pairs such as `key[]=value1&key[]=value2&key[]=value3`.
+
+The `queryParamStyle(...)` method in the `RestClientBuilder` can be used to specify the desired format of query
+parameters when multiple values are sent for the same parameter. This method uses the `QueryParamStyle` enum. Here is
+an example:
+
+[source, java]
+----
+public interface QueryClient {
+    Response sendMultiValues(@QueryParam("myParam") List<String> values);
+}
+----
+[source, java]
+----
+QueryClient client = RestClientBuilder.newBuilder()
+                                      .baseUri(someUri)
+                                      .queryParamStyle(QueryParamStyle.COMMA_SEPARATED)
+                                      .build(QueryClient.class);
+Response response = client.sendMultiValues(Collections.asList("abc", "mno", "xyz"));
+----
+
+This should send a request with a query segment of `myParam=abc,mno,xyz`.
+
+Alternatively, if the client is instantiated and injected using CDI, then the query parameter style can be configured
+using the `<client_interface_name>/mp-rest/queryParamStyle` MP Config property. See <<cdi.asciidoc#mpconfig>> for more 
+details.
+
 === Invalid Client Interface Examples
 
 Invalid client interfaces will result in a RestClientDefinitionException (which may be wrapped in a `DefinitionException` if using CDI).  Invalid interfaces can include:

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/QueryParamStyleTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/QueryParamStyleTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import java.net.URI;
+import java.util.Arrays;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.ext.QueryParamStyle;
+import org.eclipse.microprofile.rest.client.tck.interfaces.StringClient;
+import org.eclipse.microprofile.rest.client.tck.providers.ReturnWithURLRequestFilter;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+public class QueryParamStyleTest extends Arquillian {
+    @Deployment
+    public static Archive<?> createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, InheritanceTest.class.getSimpleName()+".war")
+            .addClasses(ReturnWithURLRequestFilter.class, StringClient.class);
+    }
+
+    @Test
+    public void defaultStyleIsMultiPair() throws Exception {
+        String expected = "?myParam=foo&myParam=bar&myParam=baz";
+        StringClient client = builder().build(StringClient.class);
+        test(client, expected);
+    }
+
+    @Test
+    public void explicitMultiPair() throws Exception {
+        String expected = "?myParam=foo&myParam=bar&myParam=baz";
+        StringClient client = builder().queryParamStyle(QueryParamStyle.MULTI_PAIRS)
+                                       .build(StringClient.class);
+        test(client, expected);
+    }
+
+    @Test
+    public void commaSeparated() throws Exception {
+        String expected = "?myParam=foo,bar,baz";
+        StringClient client = builder().queryParamStyle(QueryParamStyle.COMMA_SEPARATED)
+                                       .build(StringClient.class);
+        test(client, expected);
+    }
+
+    @Test
+    public void arrayPairs() throws Exception {
+        String expected = "?myParam[]=foo&myParam[]=bar&myParam[]=baz";
+        StringClient client = builder().queryParamStyle(QueryParamStyle.ARRAY_PAIRS)
+                                       .build(StringClient.class);
+        test(client, expected);
+    }
+
+    public static void test(StringClient client, String expected) {
+        String responseStr = client.multiValues(Arrays.asList("foo", "bar", "baz"));
+        assertNotNull(responseStr, "Response entity is null");
+        assertTrue(responseStr.contains(expected),
+                   "Expected snippet, " + expected + ", in: " + responseStr);
+    }
+
+    private RestClientBuilder builder() {
+        return RestClientBuilder.newBuilder()
+                                .register(new ReturnWithURLRequestFilter())
+                                .baseUri(URI.create("http://localhost/stub"));
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/CDIQueryParamStyleTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/CDIQueryParamStyleTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2020 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.cditests;
+
+import static org.eclipse.microprofile.rest.client.tck.QueryParamStyleTest.test;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.eclipse.microprofile.rest.client.tck.QueryParamStyleTest;
+import org.eclipse.microprofile.rest.client.tck.interfaces.StringClient;
+import org.eclipse.microprofile.rest.client.tck.providers.ReturnWithURLRequestFilter;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+import javax.inject.Inject;
+
+
+/**
+ * Verifies the style used when sending multiple query param values configured via MP Confg and CDI.
+ */
+public class CDIQueryParamStyleTest extends Arquillian {
+    @Inject
+    @RestClient
+    private DefaultStringClient defaultClient;
+
+    @Inject
+    @RestClient
+    private MultiPairsStringClient multiPairsClient;
+
+    @Inject
+    @RestClient
+    private CommaSeparatedStringClient commaSeparatedClient;
+
+    @Inject
+    @RestClient
+    private ArrayPairsStringClient arrayPairsClient;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        String urlProperty = "queryParamStyle/mp-rest/uri=http://localhost:8080/stub";
+        String filterProperty = "queryParamStyle/mp-rest/providers=" + ReturnWithURLRequestFilter.class.getName();
+        String multiPairsProperty = MultiPairsStringClient.class.getName()
+            + "/mp-rest/queryParamStyle=MULTI_PAIRS";
+        String commaSeparatedProperty = CommaSeparatedStringClient.class.getName()
+            + "/mp-rest/queryParamStyle=COMMA_SEPARATED";
+        String arrayPairsProperty = ArrayPairsStringClient.class.getName()
+            + "/mp-rest/queryParamStyle=ARRAY_PAIRS";
+        String simpleName = CDIQueryParamStyleTest.class.getSimpleName();
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, simpleName + ".jar")
+            .addClasses(StringClient.class, ReturnWithURLRequestFilter.class, QueryParamStyleTest.class)
+            .addAsManifestResource(new StringAsset(String.format(filterProperty + "%n" 
+                                                               + urlProperty + "%n"
+                                                               + multiPairsProperty + "%n"
+                                                               + commaSeparatedProperty + "%n"
+                                                               + arrayPairsProperty + "%n")),
+                                                   "microprofile-config.properties")
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        return ShrinkWrap.create(WebArchive.class, simpleName + ".war")
+            .addAsLibrary(jar)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    public void defaultStyleIsMultiPair() throws Exception {
+        String expected = "?myParam=foo&myParam=bar&myParam=baz";
+        test(defaultClient, expected);
+    }
+
+    @Test
+    public void explicitMultiPair() throws Exception {
+        String expected = "?myParam=foo&myParam=bar&myParam=baz";
+        test(multiPairsClient, expected);
+    }
+
+    @Test
+    public void commaSeparated() throws Exception {
+        String expected = "?myParam=foo,bar,baz";
+        test(commaSeparatedClient, expected);
+    }
+
+    @Test
+    public void arrayPairs() throws Exception {
+        String expected = "?myParam[]=foo&myParam[]=bar&myParam[]=baz";
+        test(arrayPairsClient, expected);
+    }
+
+    @RegisterRestClient(configKey = "queryParamStyle")
+    public static interface DefaultStringClient extends StringClient {
+    }
+
+    @RegisterRestClient(configKey = "queryParamStyle")
+    public static interface MultiPairsStringClient extends StringClient {
+    }
+
+    @RegisterRestClient(configKey = "queryParamStyle")
+    public static interface CommaSeparatedStringClient extends StringClient {
+    }
+    
+    @RegisterRestClient(configKey = "queryParamStyle")
+    public static interface ArrayPairsStringClient extends StringClient {
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/StringClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/StringClient.java
@@ -19,6 +19,11 @@ package org.eclipse.microprofile.rest.client.tck.interfaces;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+
+import java.util.List;
+
+import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
 
 @Path("/")
@@ -26,4 +31,7 @@ import javax.ws.rs.PUT;
 public interface StringClient {
     @PUT
     String getHeaderValue(String headerName);
+
+    @GET
+    String multiValues(@QueryParam("myParam") List<String> values);
 }


### PR DESCRIPTION
Fixes #217 - allows users to specify the style used when generating a request that uses query parameters.  The style will generate either multiple key/value pairs (MULTI_PAIRS e.g. `foo=v1&foo=v2&foo=v3`), a single pair using comma-separated values (COMMA_SEPARATED e.g. `foo=v1,v2,v3`), or multiple pairs using an array-like syntax (ARRAY_PAIRS e.g. `foo[]=v1&foo[]=v2&foo[]=v3`).

@derekm since you requested this feature, would you also take a look to ensure that this is what you were looking for?

Thanks, Andy