### PR TITLE
[#256] Use CDI-based provider if class registered

### DIFF
--- a/spec/src/main/asciidoc/cdi.asciidoc
+++ b/spec/src/main/asciidoc/cdi.asciidoc
@@ -58,6 +58,9 @@ The qualifier is used to differentiate use cases of the interface that are manag
 
 Interfaces are assumed to have a scope of `@Dependent` unless there is another scope defined on the interface.  Implementations are expected to support all of the built in scopes for a bean.  Support for custom registered scopes should work, but is not guaranteed.
 
+If the CDI implementation manages an instance of a registered provider class, the implementation must use that instance.
+See <<providers.asciidoc#cdiProviders>> for more details.
+
 [[mpconfig]]
 === Support for MicroProfile Config
 

--- a/spec/src/main/asciidoc/providers.asciidoc
+++ b/spec/src/main/asciidoc/providers.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017-2019 Contributors to the Eclipse Foundation
+// Copyright (c) 2017-2020 Contributors to the Eclipse Foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -93,6 +93,62 @@ Any methods that read the response body as a stream must ensure that they reset 
 In addition to defining providers via the client definition, interfaces may use the `@RegisterProvider` annotation to define classes to be registered as providers in addition to providers registered via the `RestClientBuilder`.
 
 Providers may also be registered by implementing the `RestClientBuilderListener` or `RestClientListener` interfaces.  These interfaces are intended as SPIs to allow global provider registration.  The implementation of these interface must be specified in a `META-INF/services/org.eclipse.microprofile.rest.client.spi.RestClientBuilderListener` or `META-INF/services/org.eclipse.microprofile.rest.client.spi.RestClientListener` file, respectively, following the `ServiceLoader` pattern.
+
+[[cdiProviders]]
+=== CDI Managed Providers
+
+If CDI is available in the implementation's runtime environment, and CDI is managing the lifecycle of a registered
+provider class, the implementation must use the CDI-managed instance of the provider. This does not apply when an
+instance is registered, nor does it apply when a class is registered but no instance of that class is managed by CDI.
+
+The following example shows cases where a CDI-managed provider instance must be used:
+
+[source, java]
+----
+@ApplicationScoped // makes it a CDI bean
+public class MyFilter implements ClientRequestFilter {
+    @Inject SomeOtherCdiObject obj;
+    // ...
+}
+
+@RegisterRestClient
+@RegisterProvider(MyFilter.class)
+public interface MyRestClient1 { /* ... */ }
+
+@RegisterRestClient
+// MP Config property: com.mycompany.MyRestClient2/mp-rest/providers=com.mycompany.MyFilter
+public interface MyRestClient2 { /* ... */ }
+
+public interface MyRestClient3 { /* ... */ }
+
+public class Client3Builder {
+
+    public MyClient3 createClient3() {
+        return RestClientBuilder.baseUri(someUri).register(MyFilter.class).build(MyClient3.class);
+    }
+}
+----
+
+When registering `Features`, it should not matter whether the feature itself is managed by CDI or not, but the
+implementation should use CDI-managed instances of classes registered by the feature. For example:
+
+[source, java]
+----
+public class MyFeature implements Feature {
+    @Override
+    public boolean configure(FeatureContext context) {
+        context.register(MyFilter.class); // will be managed by CDI
+        context.register(new MyOtherFilter()); // will not be managed by CDI
+        return true;
+    }
+}
+
+@RegisterRestClient
+@RegisterProvider(MyFeature.class)
+public interface MyRestClient4 { /* ... */ }
+----
+
+For more information on integration with CDI, see <<cdi.asciidoc#restcdi>> for more details.
 
 === Provider Priority
 

--- a/spec/src/main/asciidoc/release_notes.asciidoc
+++ b/spec/src/main/asciidoc/release_notes.asciidoc
@@ -23,12 +23,14 @@
 
 Changes since 1.4:
 
-- Added proxy server configuration support
-- Added configuration for automatically following redirect responses
-- Added support for JSON-B configuration via `ContextResolver<Jsonb>`
-- Added support for Server Sent Events
-- Changed dependency scope for most dependencies to `provided`
-- Update to use Jakarta EE 8 dependencies
+- Defined that CDI-managed providers should be used instead of creating a new instance, if applicable.
+- Support different configurations for collections used in query parameters.
+- Added proxy server configuration support.
+- Added configuration for automatically following redirect responses.
+- Added support for JSON-B configuration via `ContextResolver<Jsonb>`.
+- Added support for Server Sent Events.
+- Changed dependency scope for most dependencies to `provided`.
+- Update to use Jakarta EE 8 dependencies.
 
 [[release_notes_14]]
 == Release Notes for MicroProfile Rest Client 1.4

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/CDIManagedProviderTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/CDIManagedProviderTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2020 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.cditests;
+
+import static org.testng.Assert.assertEquals;
+
+import java.io.IOException;
+import java.net.URI;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+/**
+ * Verifies the CDI-managed providers are used when their class is registered with the client interface.
+ */
+public class CDIManagedProviderTest extends Arquillian {
+    private static final String STUB_URI = "http://localhost:9080/stub";
+
+    @Inject
+    @RestClient
+    private SimpleGetApi configClient;
+
+    @Inject
+    @RestClient
+    private MyClientWithAnnotations annotationClient;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        String uriProp = SimpleGetApi.class.getName() + "/mp-rest/uri=" + STUB_URI;
+        String providerProp = SimpleGetApi.class.getName() + "/mp-rest/providers=" + MyFilter.class.getName();
+
+        String simpleName = CDIManagedProviderTest.class.getSimpleName();
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, simpleName + ".jar")
+                .addClasses(SimpleGetApi.class)
+                .addAsManifestResource(new StringAsset(String.format(uriProp + "%n" + providerProp)), 
+                                       "microprofile-config.properties")
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        return ShrinkWrap.create(WebArchive.class, simpleName + ".war").addAsLibrary(jar)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    public void testCDIProviderSpecifiedInMPConfig() throws Exception {
+        Response r = configClient.executeGet();
+        assertEquals(r.getStatus(), 200);
+    }
+
+    @Test
+    public void testCDIProviderSpecifiedViaAnnotation() throws Exception {
+        Response r = annotationClient.executeGet();
+        assertEquals(r.getStatus(), 200);
+    }
+
+    @Test
+    public void testCDIProviderSpecifiedViaRestClientBuilder() throws Exception {
+        MyProgrammaticClient client = RestClientBuilder.newBuilder()
+                                                       .baseUri(URI.create(STUB_URI))
+                                                       .register(MyFilter.class)
+                                                       .build(MyProgrammaticClient.class);
+        Response r = client.executeGet();
+        assertEquals(r.getStatus(), 200);
+    }
+
+    @Test
+    public void testInstanceProviderSpecifiedViaRestClientBuilderDoesNotUseCDIManagedProvider() throws Exception {
+        MyProgrammaticClient client = RestClientBuilder.newBuilder()
+                                                       .baseUri(URI.create("http://localhost:9080/stub"))
+                                                       .register(new MyFilter())
+                                                       .build(MyProgrammaticClient.class);
+        Response r = client.executeGet();
+        assertEquals(r.getStatus(), 204);
+    }
+
+    @ApplicationScoped
+    public static class MyFilter implements ClientRequestFilter {
+
+        boolean postConstructInvoked;
+
+        @Inject
+        BeanManager beanManager;
+
+        @PostConstruct
+        public void postConstruct() {
+            postConstructInvoked = true;
+        }
+
+        @Override
+        public void filter(ClientRequestContext requestContext) throws IOException {
+            requestContext.abortWith(Response.status(beanManager != null  && postConstructInvoked ? 200 : 204).build());
+        }
+    }
+
+    @RegisterRestClient(baseUri = STUB_URI)
+    @RegisterProvider(MyFilter.class)
+    public static interface MyClientWithAnnotations {
+        @GET
+        Response executeGet();
+    }
+
+    public static interface MyProgrammaticClient {
+        @GET
+        Response executeGet();
+    }
+}


### PR DESCRIPTION
Fixes #256 

The net of this change is to ensure that implementations use the CDI-managed provider (if one exists) when the provider's _class_ is registered (class, as opposed to an instance).  When the class is registered (via MP Config property, `@RegisterProvider` or the `RestClientBuilder.register(...)` methods) the implementation should check if CDI is available, and then if CDI manages an instance of the provider class - if so, it should use it.  If not, then it should default back to creating a new instance of the class as before.

