### PR TITLE
Set Wiremock uri programmatically in ProxyServerTest 

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ProxyServerTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ProxyServerTest.java
@@ -79,7 +79,7 @@ public class ProxyServerTest extends WiremockArquillianTest {
             startDestinationServer("foo");
             SimpleGetApi client = RestClientBuilder.newBuilder()
                                                    .proxyAddress("localhost", getPort())
-                                                   .baseUri(URI.create("http://localhost:" + DESTINATION_SERVER_PORT + "/testProxy"))
+                                                   .baseUri(URI.create(getStringURL() + "testProxy"))
                                                    .build(SimpleGetApi.class);
             Response response = client.executeGet();
             assertEquals(response.getStatus(), 200);


### PR DESCRIPTION
Fixes the ProxyServerTest TCK by setting the wire mock server Uri to the REST Client base Uri instead of Proxy server Uri, similar to CDIProxyServerTest:
https://github.com/eclipse/microprofile-rest-client/blob/master/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/CDIProxyServerTest.java#L55