### PR TITLE
[303] update timout tests to be more resilient

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/timeout/TimeoutBuilderIndependentOfMPConfigTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/timeout/TimeoutBuilderIndependentOfMPConfigTest.java
@@ -32,14 +32,21 @@ import java.util.concurrent.TimeUnit;
 
 import static org.testng.Assert.assertTrue;
 
+/**
+ * This test verifies that even if a client is configured via MP Config, that if a separate client instance is created
+ * programmatically and using a different timeout, then the programmatically specified timeout is honored.
+ */
 public class TimeoutBuilderIndependentOfMPConfigTest extends TimeoutTestBase {
+
+    private static final int MP_CONFIG_TIMEOUT = 15000;
+    private static final int PROGRAMMATIC_TIMEOUT = 5000;
 
     @Deployment
     public static Archive<?> createDeployment() {
         String clientName = SimpleGetApi.class.getName();
-        String timeoutProps = clientName + "/mp-rest/connectTimeout=15000" +
+        String timeoutProps = clientName + "/mp-rest/connectTimeout=" + MP_CONFIG_TIMEOUT +
                               System.lineSeparator() +
-                              clientName + "/mp-rest/readTimeout=15000";
+                              clientName + "/mp-rest/readTimeout=" + MP_CONFIG_TIMEOUT;
         StringAsset mpConfig = new StringAsset(timeoutProps);
         return ShrinkWrap.create(WebArchive.class, TimeoutBuilderIndependentOfMPConfigTest.class.getSimpleName()+".war")
             .addAsWebInfResource(mpConfig, "classes/META-INF/microprofile-config.properties")
@@ -52,7 +59,7 @@ public class TimeoutBuilderIndependentOfMPConfigTest extends TimeoutTestBase {
     protected SimpleGetApi getClientWithReadTimeout() {
         return RestClientBuilder.newBuilder()
             .baseUri(WiremockArquillianTest.getServerURI())
-            .readTimeout(5, TimeUnit.SECONDS)
+            .readTimeout(PROGRAMMATIC_TIMEOUT, TimeUnit.MILLISECONDS)
             .build(SimpleGetApi.class);
     }
 
@@ -60,15 +67,16 @@ public class TimeoutBuilderIndependentOfMPConfigTest extends TimeoutTestBase {
     protected SimpleGetApi getClientWithConnectTimeout() {
         return RestClientBuilder.newBuilder()
             .baseUri(URI.create(UNUSED_URL))
-            .connectTimeout(5, TimeUnit.SECONDS)
+            .connectTimeout(PROGRAMMATIC_TIMEOUT, TimeUnit.MILLISECONDS)
             .build(SimpleGetApi.class);
     }
 
     @Override
     protected void checkTimeElapsed(long elapsed) {
-        assertTrue(elapsed >= 5);
+
+        assertTrue(elapsed >= PROGRAMMATIC_TIMEOUT - ROUNDING_FACTOR_CUSHION);
         // allow extra seconds cushion for slower test machines
-        final long elapsedLimit = 5 + TIMEOUT_CUSHION;
-        assertTrue(elapsed < elapsedLimit, "Elapsed time expected under " + elapsedLimit + " secs, but was " + elapsed + " secs.");
+        final long elapsedLimit = PROGRAMMATIC_TIMEOUT + TIMEOUT_CUSHION;
+        assertTrue(elapsed < elapsedLimit, "Elapsed time expected under " + elapsedLimit + "ms, but was " + elapsed + "ms.");
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/timeout/TimeoutTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/timeout/TimeoutTest.java
@@ -32,6 +32,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 public class TimeoutTest extends TimeoutTestBase {
+    private static final int TIMEOUT = 5000;
 
     @Deployment
     public static Archive<?> createDeployment() {
@@ -46,7 +47,7 @@ public class TimeoutTest extends TimeoutTestBase {
     protected SimpleGetApi getClientWithReadTimeout() {
         return RestClientBuilder.newBuilder()
             .baseUri(WiremockArquillianTest.getServerURI())
-            .readTimeout(5, TimeUnit.SECONDS)
+            .readTimeout(TIMEOUT, TimeUnit.MILLISECONDS)
             .build(SimpleGetApi.class);
     }
 
@@ -54,15 +55,15 @@ public class TimeoutTest extends TimeoutTestBase {
     protected SimpleGetApi getClientWithConnectTimeout() {
         return RestClientBuilder.newBuilder()
             .baseUri(URI.create(UNUSED_URL))
-            .connectTimeout(5, TimeUnit.SECONDS)
+            .connectTimeout(TIMEOUT, TimeUnit.MILLISECONDS)
             .build(SimpleGetApi.class);
     }
 
     @Override
     protected void checkTimeElapsed(long elapsed) {
-        assertTrue(elapsed >= 5);
+        assertTrue(elapsed >= TIMEOUT - ROUNDING_FACTOR_CUSHION);
         // allow extra seconds cushion for slower test machines
-        final long elapsedLimit = 5 + TIMEOUT_CUSHION;
-        assertTrue(elapsed < elapsedLimit, "Elapsed time expected under " + elapsedLimit + " secs, but was " + elapsed + " secs.");
+        final long elapsedLimit = TIMEOUT + TIMEOUT_CUSHION;
+        assertTrue(elapsed < elapsedLimit, "Elapsed time expected under " + elapsedLimit + "ms, but was " + elapsed + "ms.");
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/timeout/TimeoutTestBase.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/timeout/TimeoutTestBase.java
@@ -33,12 +33,14 @@ import javax.ws.rs.ProcessingException;
 import org.eclipse.microprofile.rest.client.tck.WiremockArquillianTest;
 import org.eclipse.microprofile.rest.client.tck.interfaces.SimpleGetApi;
 import org.testng.annotations.Test;
+import org.testng.log4testng.Logger;
 
 
 
 
 
 public abstract class TimeoutTestBase extends WiremockArquillianTest {
+    private static final Logger LOG = Logger.getLogger(TimeoutTestBase.class);
 
     protected static final String UNUSED_URL =
         AccessController.doPrivileged((PrivilegedAction<String>) () ->
@@ -51,7 +53,14 @@ public abstract class TimeoutTestBase extends WiremockArquillianTest {
         AccessController.doPrivileged((PrivilegedAction<Integer>) () ->
             Integer.getInteger(
                 "org.eclipse.microprofile.rest.client.tck.timeoutCushion",
-                10)
+                1000)
+        );
+
+    protected static final int ROUNDING_FACTOR_CUSHION =
+        AccessController.doPrivileged((PrivilegedAction<Integer>) () ->
+            Integer.getInteger(
+                "org.eclipse.microprofile.rest.client.tck.roundingFactorCushion",
+                300)
         );
 
     @Test(expectedExceptions={ProcessingException.class})
@@ -64,8 +73,11 @@ public abstract class TimeoutTestBase extends WiremockArquillianTest {
         }
         finally {
             long elapsedTime = System.nanoTime() - startTime;
-            long elapsedSecs = TimeUnit.SECONDS.convert(elapsedTime, TimeUnit.NANOSECONDS);
-            checkTimeElapsed(elapsedSecs);
+            long elapsedMs = TimeUnit.MILLISECONDS.convert(elapsedTime, TimeUnit.NANOSECONDS);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("testConnectTimeout - elapsedTime (millis) = " + elapsedMs);
+            }
+            checkTimeElapsed(elapsedMs);
         }
     }
 
@@ -82,8 +94,11 @@ public abstract class TimeoutTestBase extends WiremockArquillianTest {
         }
         finally {
             long elapsedTime = System.nanoTime() - startTime;
-            long elapsedSecs = TimeUnit.SECONDS.convert(elapsedTime, TimeUnit.NANOSECONDS);
-            checkTimeElapsed(elapsedSecs);
+            long elapsedMs = TimeUnit.MILLISECONDS.convert(elapsedTime, TimeUnit.NANOSECONDS);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("testConnectTimeout - elapsedTime (millis) = " + elapsedMs);
+            }
+            checkTimeElapsed(elapsedMs);
         }
     }
 
@@ -91,5 +106,5 @@ public abstract class TimeoutTestBase extends WiremockArquillianTest {
     protected abstract SimpleGetApi getClientWithConnectTimeout();
 
 
-    protected abstract void checkTimeElapsed(long elapsed);
+    protected abstract void checkTimeElapsed(long elapsedMS);
 }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/timeout/TimeoutViaMPConfigTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/timeout/TimeoutViaMPConfigTest.java
@@ -33,6 +33,7 @@ import javax.inject.Inject;
 import static org.testng.Assert.assertTrue;
 
 public class TimeoutViaMPConfigTest extends TimeoutTestBase {
+    private static final int TIMEOUT = 7000;
 
     @Inject
     @RestClient
@@ -43,8 +44,8 @@ public class TimeoutViaMPConfigTest extends TimeoutTestBase {
         String clientName = SimpleGetApi.class.getName();
         String timeoutProps =
                 clientName + "/mp-rest/uri=" + UNUSED_URL + System.lineSeparator() +
-                clientName + "/mp-rest/connectTimeout=7000" + System.lineSeparator() +
-                clientName + "/mp-rest/readTimeout=7000";
+                clientName + "/mp-rest/connectTimeout=" + TIMEOUT + System.lineSeparator() +
+                clientName + "/mp-rest/readTimeout=" + TIMEOUT;
         StringAsset mpConfig = new StringAsset(timeoutProps);
         return ShrinkWrap.create(WebArchive.class, TimeoutViaMPConfigTest.class.getSimpleName()+".war")
             .addAsWebInfResource(mpConfig, "classes/META-INF/microprofile-config.properties")
@@ -66,9 +67,9 @@ public class TimeoutViaMPConfigTest extends TimeoutTestBase {
 
     @Override
     protected void checkTimeElapsed(long elapsed) {
-        assertTrue(elapsed >= 7);
+        assertTrue(elapsed >= TIMEOUT - ROUNDING_FACTOR_CUSHION);
         // allow extra seconds cushion for slower test machines
-        final long elapsedLimit = 7 + TIMEOUT_CUSHION;
-        assertTrue(elapsed < elapsedLimit, "Elapsed time expected under " + elapsedLimit + " secs, but was " + elapsed + " secs.");
+        final long elapsedLimit = TIMEOUT + TIMEOUT_CUSHION;
+        assertTrue(elapsed < elapsedLimit, "Elapsed time expected under " + elapsedLimit + "ms, but was " + elapsed + "ms.");
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/timeout/TimeoutViaMPConfigWithConfigKeyTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/timeout/TimeoutViaMPConfigWithConfigKeyTest.java
@@ -34,6 +34,7 @@ import javax.inject.Inject;
 import static org.testng.Assert.assertTrue;
 
 public class TimeoutViaMPConfigWithConfigKeyTest extends TimeoutTestBase {
+    private static final int TIMEOUT = 7000;
 
     @Inject
     @RestClient
@@ -43,8 +44,8 @@ public class TimeoutViaMPConfigWithConfigKeyTest extends TimeoutTestBase {
     public static Archive<?> createDeployment() {
         String timeoutProps =
                 "myConfigKey/mp-rest/uri=" + UNUSED_URL + System.lineSeparator() +
-                "myConfigKey/mp-rest/connectTimeout=7000" + System.lineSeparator() +
-                "myConfigKey/mp-rest/readTimeout=7000";
+                "myConfigKey/mp-rest/connectTimeout=" + TIMEOUT + System.lineSeparator() +
+                "myConfigKey/mp-rest/readTimeout=" + TIMEOUT;
         StringAsset mpConfig = new StringAsset(timeoutProps);
         return ShrinkWrap.create(WebArchive.class, TimeoutViaMPConfigWithConfigKeyTest.class.getSimpleName()+".war")
             .addAsWebInfResource(mpConfig, "classes/META-INF/microprofile-config.properties")
@@ -67,9 +68,9 @@ public class TimeoutViaMPConfigWithConfigKeyTest extends TimeoutTestBase {
 
     @Override
     protected void checkTimeElapsed(long elapsed) {
-        assertTrue(elapsed >= 7);
+        assertTrue(elapsed >= TIMEOUT - ROUNDING_FACTOR_CUSHION);
         // allow extra seconds cushion for slower test machines
-        final long elapsedLimit = 7 + TIMEOUT_CUSHION;
-        assertTrue(elapsed < elapsedLimit, "Elapsed time expected under " + elapsedLimit + " secs, but was " + elapsed + " secs.");
+        final long elapsedLimit = TIMEOUT + TIMEOUT_CUSHION;
+        assertTrue(elapsed < elapsedLimit, "Elapsed time expected under " + elapsedLimit + "ms, but was " + elapsed + "ms.");
     }
 }


### PR DESCRIPTION
Fixes #303 - as mentioned in the issue, this change adds a little "fudge factor" in case of rounding errors and it uses milliseconds consistently instead of converting to seconds.