### PR TITLE
Enable SPI/ServiceLoader under OSGi

### DIFF
--- a/api/bnd.bnd
+++ b/api/bnd.bnd
@@ -9,3 +9,5 @@ Import-Package: javax.enterprise.context;version="[1.1,3)";resolution:=optional,
     javax.inject;resolution:=optional,\
     org.eclipse.microprofile.config;version="[2.0,3)";resolution:=optional,\
     *
+Require-Capability: osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)"; resolution:=optional,\
+    osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.microprofile.rest.client.spi.RestClientBuilderResolver)"; resolution:=optional


### PR DESCRIPTION
* Using OSGi's [Service Loader Mediator](https://blog.osgi.org/2013/02/javautilserviceloader-in-osgi.html) (i.e. Apache Aries [SPI Fly](https://aries.apache.org/documentation/modules/spi-fly.html))
* Made all requirements optional (minimally invasive change)

Based on the following discussion: https://github.com/eclipse/microprofile-rest-client/issues/308#issuecomment-813638983

Cheers