### PR TITLE
[330] Skip Conv-scope test in non-servlet env

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasConversationScopeTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/HasConversationScopeTest.java
@@ -18,6 +18,8 @@
 
 package org.eclipse.microprofile.rest.client.tck.cditests;
 
+import static org.eclipse.microprofile.rest.client.tck.utils.ClassUtils.canLoad;
+import static org.eclipse.microprofile.rest.client.tck.utils.TestUtils.assumeThat;
 import static org.testng.Assert.assertEquals;
 
 import java.util.Set;
@@ -69,6 +71,9 @@ public class HasConversationScopeTest extends Arquillian {
 
     @Test
     public void testHasConversationScoped() {
+        // per CDI spec, ConversationScope is only applicable when servlets are in play
+        assumeThat(canLoad("jakarta.servlet.http.HttpServlet"));
+
         Set<Bean<?>> beans = beanManager.getBeans(SimpleGetApi.class, RestClient.LITERAL);
         Bean<?> resolved = beanManager.resolve(beans);
         assertEquals(resolved.getScope(), ConversationScoped.class);
@@ -76,6 +81,9 @@ public class HasConversationScopeTest extends Arquillian {
 
     @Test
     public void testHasConversationScopedFromConfigKey() {
+        // per CDI spec, ConversationScope is only applicable when servlets are in play
+        assumeThat(canLoad("jakarta.servlet.http.HttpServlet"));
+
         Set<Bean<?>> beans = beanManager.getBeans(ConfigKeyClient.class, RestClient.LITERAL);
         Bean<?> resolved = beanManager.resolve(beans);
         assertEquals(resolved.getScope(), ConversationScoped.class);
@@ -83,6 +91,9 @@ public class HasConversationScopeTest extends Arquillian {
 
     @Test
     public void testHasConversationScopedWhenAnnotated() {
+        // per CDI spec, ConversationScope is only applicable when servlets are in play
+        assumeThat(canLoad("jakarta.servlet.http.HttpServlet"));
+
         Set<Bean<?>> beans = beanManager.getBeans(MyConversationScopedApi.class, RestClient.LITERAL);
         Bean<?> resolved = beanManager.resolve(beans);
         assertEquals(resolved.getScope(), ConversationScoped.class);

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/utils/ClassUtils.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/utils/ClassUtils.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.rest.client.tck.utils;
+
+public class ClassUtils {
+
+    public static boolean canLoad(String className) {
+        try {
+            Class.forName(className);
+            return true;
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/utils/TestUtils.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/utils/TestUtils.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.rest.client.tck.utils;
+
+import org.testng.SkipException;
+
+public class TestUtils {
+
+    public static void assumeThat(boolean assertion) {
+        assumeThat("", assertion);
+    }
+
+    public static void assumeThat(String reason, boolean assertion) {
+        if (!assertion) {
+            throw new SkipException(reason);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #330 - this will be backported to the `jakarta91-branch` branch (and `2.0.X-service` branch if requested).

This should skip the `HasConversationScopeTest` tests if no servlet APIs are available.

@radcortez can you verify that your non-servlet implementation passes(skips) these tests with this fix?  Thanks!