### PR TITLE
Replace javax namespace usage with jakarta and align with Microprofile 6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.microprofile</groupId>
         <artifactId>microprofile-parent</artifactId>
-        <version>2.6</version>
+        <version>3.0</version>
     </parent> 
 
     <groupId>org.eclipse.microprofile.rest.client</groupId>
@@ -35,7 +35,12 @@
     <properties>
         <version.mp.config>3.0</version.mp.config>
         <inceptionYear>2017</inceptionYear>
-        <version.microprofile.tck.bom>2.6</version.microprofile.tck.bom>
+        <version.microprofile.tck.bom>3.0</version.microprofile.tck.bom>
+        <version.jakarta.annotation>2.0.0</version.jakarta.annotation>
+        <version.jakarta.cdi>3.0.0</version.jakarta.cdi>
+        <version.jakarta.ws-rs>3.0.0</version.jakarta.ws-rs>
+        <version.jakarta.jsonp>2.0.0</version.jakarta.jsonp>
+        <version.jakarta.jsonb>2.0.0</version.jakarta.jsonb>
     </properties>
 
     <dependencyManagement>
@@ -52,6 +57,51 @@
                 <groupId>org.eclipse.microprofile.rest.client</groupId>
                 <artifactId>microprofile-rest-client-api</artifactId>
                 <version>${project.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.annotation</groupId>
+                <artifactId>jakarta.annotation-api</artifactId>
+                <version>${version.jakarta.annotation}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
+                <version>${version.jakarta.cdi}</version>
+                <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>jakarta.el</groupId>
+                        <artifactId>jakarta.el-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>jakarta.ejb</groupId>
+                        <artifactId>jakarta.ejb-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
+                <version>${version.jakarta.ws-rs}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.json</groupId>
+                <artifactId>jakarta.json-api</artifactId>
+                <version>${version.jakarta.jsonp}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.json.bind</groupId>
+                <artifactId>jakarta.json.bind-api</artifactId>
+                <version>${version.jakarta.jsonb}</version>
                 <scope>provided</scope>
             </dependency>
         </dependencies>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock</artifactId>
-            <version>2.27.2</version>
+            <version>3.0.0-beta-2</version>
         </dependency>
         <dependency>
             <groupId>jakarta.ws.rs</groupId>

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ProxyServerTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ProxyServerTest.java
@@ -26,9 +26,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URI;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.AbstractHandler;
@@ -39,6 +36,8 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.ws.rs.core.Response;
 
 public class ProxyServerTest extends WiremockArquillianTest {

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/sse/MyEventSourceServlet.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/sse/MyEventSourceServlet.java
@@ -19,10 +19,10 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
 
-import javax.servlet.http.HttpServletRequest;
-
 import org.eclipse.jetty.servlets.EventSource;
 import org.eclipse.jetty.servlets.EventSourceServlet;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 public class MyEventSourceServlet extends EventSourceServlet {
     private static final long serialVersionUID = -45238967561209543L;

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ssl/HttpsServer.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ssl/HttpsServer.java
@@ -18,10 +18,7 @@ package org.eclipse.microprofile.rest.client.tck.ssl;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import org.apache.http.entity.ContentType;
+import org.apache.hc.core5.http.ContentType;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
@@ -31,6 +28,9 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  *
@@ -44,7 +44,7 @@ public class HttpsServer {
     private static final String CONTENT_TYPE = "Content-Type";
 
     private final Server server = new Server();
-    private SslContextFactory sslContextFactory = new SslContextFactory();
+    private SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
 
     private String responseContent = "{\"foo\": \"bar\"}";
     private String responseContentType = ContentType.APPLICATION_JSON.getMimeType();

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ssl/SslContextTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ssl/SslContextTest.java
@@ -17,7 +17,7 @@ package org.eclipse.microprofile.rest.client.tck.ssl;
 
 import javax.net.ssl.SSLContext;
 
-import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.hc.core5.ssl.SSLContextBuilder;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.tck.interfaces.JsonPClient;
 import org.jboss.arquillian.container.test.api.Deployment;


### PR DESCRIPTION
The Microprofile 6.0 is out and aligns with Jakarta EE 10 Core Profile. It is still bundles [MicroProfile Rest Client 3.0](https://github.com/eclipse/microprofile-rest-client/releases/tag/3.0.1) [1] but the minimum Java SE version now is **Java SE 11 or higher** [2]. With that in mind, we could fix the remaining `javax.*` -> `jakarta.*` by updating to Wiremock  3.0.0 (which uses Jetty 11). 

[1] https://github.com/eclipse/microprofile/releases/tag/6.0
[2] https://jakarta.ee/specifications/coreprofile/10/