### PR TITLE
[341] Upgrade Wiremock, which also upgrades Jetty. Also upgrade TestN…

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.5.1</version>
+            <version>7.8.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/tck/README.adoc
+++ b/tck/README.adoc
@@ -35,7 +35,7 @@ To enable the tests in your project you need to add the following dependency to 
 [source, xml]
 ----
 <properties>
-   <microprofile.rest.client.version>3.0</microprofile.rest.client.version>
+   <microprofile.rest.client.version>3.1</microprofile.rest.client.version>
 </properties>
 
 <dependency>
@@ -53,13 +53,12 @@ To enable the tests in your project you need to add the following dependency to 
 <dependency>
     <groupId>org.testng</groupId>
     <artifactId>testng</artifactId>
-    <version>7.4.0</version>
     <scope>test</scope>
 </dependency>
 <dependency>
     <groupId>com.github.tomakehurst</groupId>
     <artifactId>wiremock</artifactId>
-    <version>2.27.2</version>
+    <version>3.0.1</version>
     <scope>test</scope>
 </dependency>
 ----
@@ -73,7 +72,7 @@ WireMock can be run as a maven plugin.  Below is one example configuration:
 <plugin>
     <groupId>uk.co.deliverymind</groupId>
     <artifactId>wiremock-maven-plugin</artifactId>
-    <version>2.7.0</version>
+    <version>7.3.0</version>
     <executions>
         <execution>
             <phase>generate-test-sources</phase>
@@ -156,7 +155,6 @@ If you use Apache Maven then the tests are run via the `maven-surefire-plugin`
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>2.19.1</version>
             <configuration>
                 <suiteXmlFiles>
                     <suiteXmlFile>tck-suite.xml</suiteXmlFile>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -53,18 +53,8 @@
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
-            <!-- actually only referenced in JavaDoc -->
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-annotation_1.2_spec</artifactId>
-            <version>1.0</version>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-atinject_1.0_spec</artifactId>
-            <version>1.0</version>
-            <scope>provided</scope>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.json</groupId>
@@ -73,6 +63,10 @@
         <dependency>
             <groupId>jakarta.json.bind</groupId>
             <artifactId>jakarta.json.bind-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>
@@ -85,7 +79,7 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock</artifactId>
-            <version>2.27.2</version>
+            <version>3.0.1</version>
         </dependency>
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
@@ -98,5 +92,5 @@
         </dependency>
     </dependencies>
 
-   
+
 </project>

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ProxyServerTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ProxyServerTest.java
@@ -26,9 +26,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URI;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.AbstractHandler;
@@ -39,6 +36,8 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.ws.rs.core.Response;
 
 public class ProxyServerTest extends WiremockArquillianTest {

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/WiremockArquillianTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/WiremockArquillianTest.java
@@ -59,7 +59,7 @@ public abstract class WiremockArquillianTest extends Arquillian {
 
     protected static String getStringURL() {
         int port = getPort();
-        return scheme + "://" + host + ":" + port + "" + context;
+        return scheme + "://" + host + ":" + port + (context.isBlank() ? "/" : context);
     }
 
     @BeforeClass
@@ -73,6 +73,6 @@ public abstract class WiremockArquillianTest extends Arquillian {
         host = System.getProperty("wiremock.server.host", "localhost");
         port = Integer.parseInt(System.getProperty("wiremock.server.port", "8765"));
         scheme = System.getProperty("wiremock.server.scheme", "http");
-        context = System.getProperty("wiremock.server.context", "/");
+        context = System.getProperty("wiremock.server.context", "");
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/sse/MyEventSourceServlet.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/sse/MyEventSourceServlet.java
@@ -19,10 +19,10 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
 
-import javax.servlet.http.HttpServletRequest;
-
 import org.eclipse.jetty.servlets.EventSource;
 import org.eclipse.jetty.servlets.EventSourceServlet;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 public class MyEventSourceServlet extends EventSourceServlet {
     private static final long serialVersionUID = -45238967561209543L;

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ssl/HttpsServer.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ssl/HttpsServer.java
@@ -18,19 +18,20 @@ package org.eclipse.microprofile.rest.client.tck.ssl;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import org.apache.http.entity.ContentType;
+import org.apache.hc.core5.http.ContentType;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.SecureRequestCustomizer;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  *
@@ -44,7 +45,7 @@ public class HttpsServer {
     private static final String CONTENT_TYPE = "Content-Type";
 
     private final Server server = new Server();
-    private SslContextFactory sslContextFactory = new SslContextFactory();
+    private SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
 
     private String responseContent = "{\"foo\": \"bar\"}";
     private String responseContentType = ContentType.APPLICATION_JSON.getMimeType();
@@ -83,6 +84,11 @@ public class HttpsServer {
         HttpConfiguration httpsConfig = new HttpConfiguration(); // httpConfig);
         httpsConfig.setSecureScheme("https");
         httpsConfig.setSecurePort(httpsPort);
+        // We need to disable SNI checking as localhost is restricted.
+        final SecureRequestCustomizer customizer = new SecureRequestCustomizer();
+        customizer.setSniRequired(false);
+        customizer.setSniHostCheck(false);
+        httpsConfig.addCustomizer(customizer);
 
         ServerConnector sslConnector = new ServerConnector(server,
                 new SslConnectionFactory(sslContextFactory, HttpVersion.HTTP_1_1.asString()),

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ssl/SslContextTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ssl/SslContextTest.java
@@ -17,7 +17,7 @@ package org.eclipse.microprofile.rest.client.tck.ssl;
 
 import javax.net.ssl.SSLContext;
 
-import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.hc.core5.ssl.SSLContextBuilder;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.tck.interfaces.JsonPClient;
 import org.jboss.arquillian.container.test.api.Deployment;


### PR DESCRIPTION
…G. All these upgrades required some additional changes.

resolves #341 
resolves #346

Locally I ran this against resteasy-microprofile. While it required some dependencies changes there too, this passed the TCK there.
```
[INFO] Results:
[INFO] 
[WARNING] Tests run: 226, Failures: 0, Errors: 0, Skipped: 13
[INFO] 
[INFO] 
[INFO] --- jar:3.1.2:jar (default-jar) @ microprofile-rest-client-tck ---
[INFO] Building jar: /home/jperkins/projects/resteasy/resteasy-microprofile/testsuite/microprofile-rest-client-tck/target/microprofile-rest-client-tck-2.1.6.Final-SNAPSHOT.jar
[INFO] 
[INFO] --- source:3.1.0:jar-no-fork (attach-sources) @ microprofile-rest-client-tck ---
[INFO] No sources in project. Archive not created.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  05:00 min
[INFO] Finished at: 2024-01-22T16:19:03-08:00
[INFO] ------------------------------------------------------------------------
```