### PR TITLE
[348] Clarify that when a client injected as a CDI bean falls out of …

### DIFF
--- a/spec/src/main/asciidoc/lifecycle.asciidoc
+++ b/spec/src/main/asciidoc/lifecycle.asciidoc
@@ -23,6 +23,8 @@ When closed, a client instance is expected to throw an `IllegalStateException` w
 
 When a client instance is closed, the implementation is expected to clean up any underlying resources.
 
+=== Builder API
+
 A client instance can be closed by casting the instance to a `Closeable` or `AutoCloseable` and invoking the the `close()` method (or auto-invoked if using in a try-with-resources block).
 For example:
 
@@ -67,3 +69,7 @@ try (MyServiceClient c = client) {
 
 String response2 = client.greet(); // throws IllegalStateException
 ----
+
+=== Injected Client
+
+Implementations must close a client once the CDI bean falls out of scope.

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/ClientClosedTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/ClientClosedTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2024 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.cditests;
+
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.eclipse.microprofile.rest.client.tck.interfaces.cdi.scoped.AutoCloseableClient;
+import org.eclipse.microprofile.rest.client.tck.interfaces.cdi.scoped.CloseableClient;
+import org.eclipse.microprofile.rest.client.tck.interfaces.cdi.scoped.StringClient;
+import org.eclipse.microprofile.rest.client.tck.providers.ReturnWith200RequestFilter;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Tests that clients are closed when destroyed by the CDI container.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class ClientClosedTest extends Arquillian {
+
+    @Deployment
+    public static Archive<?> createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, ClientClosedTest.class.getSimpleName() + ".war")
+            .addClasses(ReturnWith200RequestFilter.class, AutoCloseableClient.class,
+                CloseableClient.class, StringClient.class, RestActivator.class)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Inject
+    BeanManager beanManager;
+
+    /**
+     * Tests that a client that does not explicitly extend {@link java.io.Closeable} or {@link AutoCloseable} is closed
+     * when the CDI bean is destroyed.
+     */
+    @Test
+    public void stringClosed() {
+        checkClient(StringClient.class);
+    }
+
+    /**
+     * Test that a client which extends {@link AutoCloseable} is closed when the CDI bean is destroyed.
+     */
+    @Test
+    public void autoCloseableClosed() {
+        checkClient(AutoCloseableClient.class);
+    }
+
+    /**
+     * Test that a client which extends {@link java.io.Closeable} is closed when the CDI bean is destroyed.
+     */
+    @Test
+    public void closeableClosed() {
+        checkClient(CloseableClient.class);
+    }
+
+    private <T extends StringClient> void checkClient(final Class<T> type) {
+        final Bean<T> resolved = lookup(type);
+        final CreationalContext<T> ctx = beanManager.createCreationalContext(resolved);
+        final T client = resolved.create(ctx);
+        Assert.assertNotNull(client);
+        // Assert the response that the client works
+        Assert.assertTrue(client.executeGet().startsWith("GET: "));
+        resolved.destroy(client, ctx);
+        // The bean has been destroyed, expect an IllegalStateException if the method is invoked per the specification
+        Assert.expectThrows("Expected an IllegalStateException to be thrown", IllegalStateException.class,
+            client::executeGet);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> Bean<T> lookup(final Class<T> type) {
+        return (Bean<T>) beanManager.resolve(beanManager.getBeans(type, RestClient.LITERAL));
+    }
+
+    @ApplicationPath("/")
+    public static class RestActivator extends Application {
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/cdi/scoped/AutoCloseableClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/cdi/scoped/AutoCloseableClient.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces.cdi.scoped;
+
+import jakarta.ws.rs.Path;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@Path("/")
+// The host/port is hard-coded here as it is not currently used. The StringClientRequestFilter is used to abort the
+// request with a 200 response code.
+@RegisterRestClient(baseUri = "http://localhost:8080")
+@RegisterProvider(StringClientRequestFilter.class)
+public interface AutoCloseableClient extends StringClient, AutoCloseable {
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/cdi/scoped/CloseableClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/cdi/scoped/CloseableClient.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces.cdi.scoped;
+
+import java.io.Closeable;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import jakarta.ws.rs.Path;
+
+@Path("/")
+// The host/port is hard-coded here as it is not currently used. The StringClientRequestFilter is used to abort the
+// request with a 200 response code.
+@RegisterRestClient(baseUri = "http://localhost:8080")
+@RegisterProvider(StringClientRequestFilter.class)
+public interface CloseableClient extends StringClient, Closeable {
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/cdi/scoped/StringClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/cdi/scoped/StringClient.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces.cdi.scoped;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@Path("/")
+// The host/port is hard-coded here as it is not currently used. The StringClientRequestFilter is used to abort the
+// request with a 200 response code.
+@RegisterRestClient(baseUri = "http://localhost:8080")
+@RegisterProvider(StringClientRequestFilter.class)
+public interface StringClient {
+
+    @GET
+    String executeGet();
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/cdi/scoped/StringClientRequestFilter.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/cdi/scoped/StringClientRequestFilter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces.cdi.scoped;
+
+import java.io.IOException;
+
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestFilter;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@Provider
+public class StringClientRequestFilter implements ClientRequestFilter {
+    @Override
+    public void filter(final ClientRequestContext requestContext) throws IOException {
+        requestContext
+                .abortWith(Response.ok(String.format("%s: %s", requestContext.getMethod(), requestContext.getUri()))
+                        .build());
+    }
+}


### PR DESCRIPTION
…scope, the client is closed. Add TCK tests to assert this behavior.

resolves #348 