### PR TITLE
Use the correct paths to trigger CI.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,18 +5,20 @@ on:
     branches-ignore:
       - 'dependabot/**'
     paths:
+        - '.github/workflows/maven.yml'
         - '**/pom.xml'
-        - 'api'
-        - 'spec'
-        - 'tck'
+        - 'api/**'
+        - 'spec/**'
+        - 'tck/**'
   pull_request:
     branches:
       - '**'
     paths:
+        - '.github/workflows/maven.yml'
         - '**/pom.xml'
-        - 'api'
-        - 'spec'
-        - 'tck'
+        - 'api/**'
+        - 'spec/**'
+        - 'tck/**'
 
 # Only run the latest job
 concurrency:

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/ClientClosedTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/ClientClosedTest.java
@@ -18,12 +18,6 @@
 
 package org.eclipse.microprofile.rest.client.tck.cditests;
 
-import jakarta.enterprise.context.spi.CreationalContext;
-import jakarta.enterprise.inject.spi.Bean;
-import jakarta.enterprise.inject.spi.BeanManager;
-import jakarta.inject.Inject;
-import jakarta.ws.rs.ApplicationPath;
-import jakarta.ws.rs.core.Application;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.eclipse.microprofile.rest.client.tck.interfaces.cdi.scoped.AutoCloseableClient;
 import org.eclipse.microprofile.rest.client.tck.interfaces.cdi.scoped.CloseableClient;
@@ -38,6 +32,13 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
 /**
  * Tests that clients are closed when destroyed by the CDI container.
  *
@@ -48,9 +49,9 @@ public class ClientClosedTest extends Arquillian {
     @Deployment
     public static Archive<?> createDeployment() {
         return ShrinkWrap.create(WebArchive.class, ClientClosedTest.class.getSimpleName() + ".war")
-            .addClasses(ReturnWith200RequestFilter.class, AutoCloseableClient.class,
-                CloseableClient.class, StringClient.class, RestActivator.class)
-            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addClasses(ReturnWith200RequestFilter.class, AutoCloseableClient.class,
+                        CloseableClient.class, StringClient.class, RestActivator.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
     @Inject
@@ -91,7 +92,7 @@ public class ClientClosedTest extends Arquillian {
         resolved.destroy(client, ctx);
         // The bean has been destroyed, expect an IllegalStateException if the method is invoked per the specification
         Assert.expectThrows("Expected an IllegalStateException to be thrown", IllegalStateException.class,
-            client::executeGet);
+                client::executeGet);
     }
 
     @SuppressWarnings("unchecked")

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/cdi/scoped/AutoCloseableClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/cdi/scoped/AutoCloseableClient.java
@@ -16,9 +16,10 @@
 
 package org.eclipse.microprofile.rest.client.tck.interfaces.cdi.scoped;
 
-import jakarta.ws.rs.Path;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import jakarta.ws.rs.Path;
 
 @Path("/")
 // The host/port is hard-coded here as it is not currently used. The StringClientRequestFilter is used to abort the

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/cdi/scoped/StringClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/cdi/scoped/StringClient.java
@@ -16,10 +16,11 @@
 
 package org.eclipse.microprofile.rest.client.tck.interfaces.cdi.scoped;
 
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.Path;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>


### PR DESCRIPTION
Note on the second commit. For some reason the `formatter-maven-plugin` was not being invoked by default. ~~It seems after #374 being merged, it started being invoked.~~

I did checkout a tag and apparently I'm wrong, this has been enabled the whole time. I don't know why this didn't get invoked for the #371 PR. Possibly it was out of date with main, I'm not sure.