### PR TITLE
[283] Add new RestClientBuilder method for adding headers.

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/rest/client/RestClientBuilder.java
@@ -270,6 +270,20 @@ public interface RestClientBuilder extends Configurable<RestClientBuilder> {
     RestClientBuilder queryParamStyle(QueryParamStyle style);
 
     /**
+     * Add an arbitrary header.
+     *
+     * @param name
+     *            - the name of the header
+     * @param name
+     *            - the value of the HTTP header to add to the request.
+     * @return the current builder with the header added to the request.
+     * @throws NullPointerException
+     *             if the value is null.
+     * @since 4.0
+     */
+    RestClientBuilder header(String name, Object value);
+
+    /**
      * Based on the configured RestClientBuilder, creates a new instance of the given REST interface to invoke API calls
      * against.
      *

--- a/api/src/test/java/org/eclipse/microprofile/rest/client/BuilderImpl1.java
+++ b/api/src/test/java/org/eclipse/microprofile/rest/client/BuilderImpl1.java
@@ -91,6 +91,11 @@ public class BuilderImpl1 extends AbstractBuilder {
     }
 
     @Override
+    public RestClientBuilder header(String name, Object value) {
+        throw new IllegalStateException("not implemented");
+    }
+
+    @Override
     public <T> T build(Class<T> clazz) {
         throw new IllegalStateException("not implemented");
     }

--- a/api/src/test/java/org/eclipse/microprofile/rest/client/BuilderImpl2.java
+++ b/api/src/test/java/org/eclipse/microprofile/rest/client/BuilderImpl2.java
@@ -91,6 +91,11 @@ public class BuilderImpl2 extends AbstractBuilder {
     }
 
     @Override
+    public RestClientBuilder header(String name, Object value) {
+        throw new IllegalStateException("not implemented");
+    }
+
+    @Override
     public <T> T build(Class<T> clazz) {
         throw new IllegalStateException("not implemented");
     }

--- a/spec/src/main/asciidoc/clientexamples.asciidoc
+++ b/spec/src/main/asciidoc/clientexamples.asciidoc
@@ -149,6 +149,19 @@ implementation must invoke the `DefaultClientHeadersFactoryImpl`. This default f
 
 `org.eclipse.microprofile.rest.client.propagateHeaders`
 
+You can also configure headers on a per instance basis using the `RestClientBuilder.header(String name, Object value)` method. Headers added via this method will be merged with the headers added via `@ClientHeaderParam` annotations, `@HeaderParam` annotations, and `ClientHeadersFactory` implementations.
+**Note: The method will throw a `NullPointerException` if the value is `null`.**
+
+Example:
+
+[source, java]
+----
+RedirectClient client = RestClientBuilder.newBuilder()
+                                         .baseUri(someUri)
+                                         .header("Some-Header", headerValueObj)
+                                         .build(SomeClient.class);
+----
+
 === Following Redirect Responses
 
 By default, a Rest Client instance will not automatically follow redirect responses. Redirect responses are typically responses with status codes in the 300 range and include `Location` header that indicates the URL of the redirected resource.

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ClientBuilderHeaderTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ClientBuilderHeaderTest.java
@@ -47,8 +47,7 @@ public class ClientBuilderHeaderTest extends Arquillian {
         return ShrinkWrap.create(WebArchive.class, ClientBuilderHeaderTest.class.getSimpleName() + ".war")
                 .addClasses(
                         ClientBuilderHeaderMethodClient.class,
-                        ReturnWithAllDuplicateClientHeadersFilter.class,
-                        WiremockArquillianTest.class);
+                        ReturnWithAllDuplicateClientHeadersFilter.class);
     }
 
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ClientBuilderHeaderTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ClientBuilderHeaderTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2024 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.tck.interfaces.ClientBuilderHeaderClient;
+import org.eclipse.microprofile.rest.client.tck.providers.ReturnWithAllClientHeadersFilter;
+import org.eclipse.microprofile.rest.client.tck.providers.ReturnWithAllDuplicateClientHeadersFilter;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import com.github.tomakehurst.wiremock.client.MappingBuilder;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+
+public class ClientBuilderHeaderTest extends WiremockArquillianTest {
+    @Deployment
+    public static Archive<?> createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, ClientBuilderHeaderTest.class.getSimpleName() + ".war")
+                .addClasses(
+                        ClientBuilderHeaderClient.class,
+                        ReturnWithAllDuplicateClientHeadersFilter.class,
+                        WiremockArquillianTest.class);
+    }
+
+    private static void stub(String expectedHeaderName, String... expectedHeaderValue) {
+        String expectedIncomingHeader = Arrays.stream(expectedHeaderValue)
+                .collect(Collectors.joining(","));
+        String outputBody = expectedIncomingHeader.replace(',', '-');
+        MappingBuilder mappingBuilder = get(urlEqualTo("/"));
+
+        // headers can be sent either in a single line with comma-separated values or in multiple lines
+        // this should match both cases:
+        Arrays.stream(expectedHeaderValue)
+                .forEach(val -> mappingBuilder.withHeader(expectedHeaderName, containing(val)));
+        stubFor(
+                mappingBuilder
+                        .willReturn(
+                                aResponse().withStatus(200)
+                                        .withBody(outputBody)));
+    }
+    @BeforeTest
+    public void resetWiremock() {
+        setupServer();
+    }
+
+    @Test
+    public void testHeaderBuilderMethod() {
+        stub("InterfaceAndBuilderHeader", "builder", "interface", "method");
+
+        RestClientBuilder builder = RestClientBuilder.newBuilder().baseUri(getServerURI());
+        builder.register(ReturnWithAllClientHeadersFilter.class);
+        builder.header("InterfaceAndBuilderHeader", "builder");
+        ClientBuilderHeaderClient client = builder.build(ClientBuilderHeaderClient.class);
+
+        JsonObject headers = client.getAllHeaders("headerparam");
+        JsonArray header = headers.getJsonArray("InterfaceAndBuilderHeader");
+        final List<String> headerValues =
+                header.stream().map(v -> v.toString().toLowerCase()).collect(Collectors.toList());
+
+        assertTrue(headerValues.contains("builder"),
+                "Header InterfaceAndBuilderHeader did not container \"builder\": " + headers);
+        assertTrue(headerValues.contains("interface"),
+                "Header InterfaceAndBuilderHeader did not container \"interface\": " + headers);
+        assertTrue(headerValues.contains("method"),
+                "Header InterfaceAndBuilderHeader did not container \"method\": " + headers);
+        assertTrue(headers.get("HeaderParam").toString().contains("headerparam"),
+                "Header HeaderParam did not container \"headerparam\": " + headers);
+    }
+
+    @Test
+    public void testHeaderBuilderMethodNullValue() {
+        stub("BuilderHeader", "BuilderHeaderValue");
+
+        RestClientBuilder builder = RestClientBuilder.newBuilder().baseUri(getServerURI());
+        try {
+            builder.header("BuilderHeader", null);
+        } catch (NullPointerException npe) {
+            return;
+        }
+        fail("header(\"builderHeader\", null) should have thrown a NullPointerException");
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/ClientBuilderHeaderClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/ClientBuilderHeaderClient.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.interfaces;
+
+import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam;
+
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.Path;
+
+@ClientHeaderParam(name = "InterfaceAndBuilderHeader", value = "interface")
+@Path("/")
+public interface ClientBuilderHeaderClient {
+
+    @GET
+    @ClientHeaderParam(name = "InterfaceAndBuilderHeader", value = "method")
+    JsonObject getAllHeaders(@HeaderParam("HeaderParam") String param);
+}

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/ClientBuilderHeaderMethodClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/interfaces/ClientBuilderHeaderMethodClient.java
@@ -25,10 +25,10 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.Path;
 
-@ClientHeaderParam(name = "InterfaceAndBuilderHeader", value = "interface")
 @Path("/")
-public interface ClientBuilderHeaderClient {
+public interface ClientBuilderHeaderMethodClient {
 
     @GET
+    @ClientHeaderParam(name = "InterfaceAndBuilderHeader", value = "method")
     JsonObject getAllHeaders(@HeaderParam("HeaderParam") String param);
 }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/ReturnWithAllDuplicateClientHeadersFilter.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/providers/ReturnWithAllDuplicateClientHeadersFilter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018, 2021 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client.tck.providers;
+
+import java.io.IOException;
+import java.util.List;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestFilter;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+
+public class ReturnWithAllDuplicateClientHeadersFilter implements ClientRequestFilter {
+
+    @Override
+    public void filter(ClientRequestContext clientRequestContext) throws IOException {
+        JsonObjectBuilder allClientHeaders = Json.createObjectBuilder();
+        MultivaluedMap<String, Object> clientHeaders = clientRequestContext.getHeaders();
+        for (String headerName : clientHeaders.keySet()) {
+            List<Object> header = clientHeaders.get(headerName);
+            final JsonArrayBuilder headerValues = Json.createArrayBuilder();
+            header.forEach(h -> headerValues.add(h.toString()));
+            allClientHeaders.add(headerName, headerValues);
+        }
+        clientRequestContext.abortWith(Response.ok(allClientHeaders.build()).build());
+    }
+
+}


### PR DESCRIPTION
Add a new `RestClientBuilder.header(String, Object)` method to add headers.

#fixes #283