### PR TITLE
Clarify specification text for CDI support

### DIFF
--- a/spec/src/main/asciidoc/cdi.asciidoc
+++ b/spec/src/main/asciidoc/cdi.asciidoc
@@ -17,7 +17,7 @@
 [[restcdi]]
 == MicroProfile Rest Client CDI Support
 
-Rest Client interfaces may be injected as CDI beans.  The runtime must create a CDI bean for each interface annotated with `RegisterRestClient`.  The bean created will include a qualifier `@RestClient` to differentiate the use as an API call against any other beans registered of the same type.  Based on the rules of how CDI resolves bean, you are only required to use the qualifier if you have multiple beans of the same type.  Any injection point or programmatic look up that uses the qualifier `RestClient` is expected to be resolved by the MicroProfile Rest Client runtime.  Below is an example of said interface, with its matching injection point:
+Rest Client interfaces may be injected as CDI beans.  The runtime must create a CDI bean for each interface annotated with `RegisterRestClient`.  The resulting bean always contains the `@RestClient` CDI qualifier to differentiate them from any other CDI bean with the same type. Any injection point or programmatic look up that uses the qualifier `RestClient` is expected to be resolved by the MicroProfile Rest Client runtime.  Below is an example of said interface, with its matching injection point:
 
 [source, java]
 ----


### PR DESCRIPTION
Fixes #381 

See linked issue for detailed explanation.
In short, The `@RestClient` qualifier is not optional and its presence is there to make sure rest client beans don't clash (and cause ambig. dependency resolution) with any other CDI bean with the same type.

This isn't changing current behavior, it is merely a removal of an incorrect explanation of CDI resolution rules.