### PR TITLE
Follow up TCK fixes for two types missing from deployments.

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ClientBuilderHeaderTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/ClientBuilderHeaderTest.java
@@ -46,6 +46,7 @@ public class ClientBuilderHeaderTest extends Arquillian {
     public static Archive<?> createDeployment() {
         return ShrinkWrap.create(WebArchive.class, ClientBuilderHeaderTest.class.getSimpleName() + ".war")
                 .addClasses(
+                        ClientBuilderHeaderClient.class,
                         ClientBuilderHeaderMethodClient.class,
                         ReturnWithAllDuplicateClientHeadersFilter.class);
     }

--- a/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/ClientClosedTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/rest/client/tck/cditests/ClientClosedTest.java
@@ -22,7 +22,7 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.eclipse.microprofile.rest.client.tck.interfaces.cdi.scoped.AutoCloseableClient;
 import org.eclipse.microprofile.rest.client.tck.interfaces.cdi.scoped.CloseableClient;
 import org.eclipse.microprofile.rest.client.tck.interfaces.cdi.scoped.StringClient;
-import org.eclipse.microprofile.rest.client.tck.providers.ReturnWith200RequestFilter;
+import org.eclipse.microprofile.rest.client.tck.interfaces.cdi.scoped.StringClientRequestFilter;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
@@ -49,7 +49,7 @@ public class ClientClosedTest extends Arquillian {
     @Deployment
     public static Archive<?> createDeployment() {
         return ShrinkWrap.create(WebArchive.class, ClientClosedTest.class.getSimpleName() + ".war")
-                .addClasses(ReturnWith200RequestFilter.class, AutoCloseableClient.class,
+                .addClasses(StringClientRequestFilter.class, AutoCloseableClient.class,
                         CloseableClient.class, StringClient.class, RestActivator.class)
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }


### PR DESCRIPTION
These were not previously caught because the TCK in the RESTEasy MicroProfile project was run in embedded Jetty. However, these need to be fixed to run other containers which truly isolate deployments.